### PR TITLE
fix: refactor hero media layer to prevent mobile video stuttering on …

### DIFF
--- a/components/features/hero/HeroMediaLayer.tsx
+++ b/components/features/hero/HeroMediaLayer.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useRef } from 'react';
 import { HeroMedia, HeroTransitionMode } from './types';
-import { motion, AnimatePresence } from 'framer-motion';
+import { motion } from 'framer-motion';
 
 interface HeroMediaLayerProps {
   media: HeroMedia[];
@@ -31,62 +31,78 @@ export const HeroMediaLayer: React.FC<HeroMediaLayerProps> = ({
     }
     return (
       <div className="absolute inset-0">
-        <MediaItem item={backupMedia} isActive={true} />
+        <MediaItem item={backupMedia} isActive={true} transitionMs={0} />
       </div>
     );
   }
 
-  const activeItem = media[activeIndex];
-
   const variants = {
     fade: {
-      initial: { opacity: 0 },
-      animate: { opacity: 1 },
-      exit: { opacity: 0 }
+      opacity: 1
     },
     slide: {
-      initial: { opacity: 0, x: '3%' },
-      animate: { opacity: 1, x: '0%' },
-      exit: { opacity: 0, x: '-3%' }
+      opacity: 1,
+      x: '0%'
     }
   };
 
-  const selectedVariant = variants[transitionMode];
+  const hiddenVariants = {
+    fade: {
+      opacity: 0
+    },
+    slide: {
+      opacity: 0,
+      x: '3%' // or -3% depending on direction, simplified here
+    }
+  };
 
   return (
     <div className="absolute inset-0 overflow-hidden bg-black">
-      <AnimatePresence mode="popLayout">
-        <motion.div
-          key={activeItem.id}
-          initial="initial"
-          animate="animate"
-          exit="exit"
-          variants={selectedVariant}
-          transition={{ duration: transitionMs / 1000, ease: 'easeInOut' }}
-          className="absolute inset-0 w-full h-full"
-        >
-          <MediaItem item={activeItem} isActive={true} />
-        </motion.div>
-      </AnimatePresence>
+      {media.map((item, index) => {
+        const isActive = index === activeIndex;
 
-      {/* 2本目以降の遅延プリロード用 (DOMツリーには入れるが非表示にする。videoのpreload="auto"を活かすため) */}
-      <div className="hidden">
-        {media.map((item, index) => {
-          if (index === activeIndex) return null;
-          return <MediaItem key={`preload-${item.id}`} item={item} isActive={false} />;
-        })}
-      </div>
+        return (
+          <motion.div
+            key={item.id}
+            initial={false}
+            animate={isActive ? variants[transitionMode] : hiddenVariants[transitionMode]}
+            transition={{ duration: transitionMs / 1000, ease: 'easeInOut' }}
+            className="absolute inset-0 w-full h-full"
+            style={{ 
+              zIndex: isActive ? 10 : 1,
+              pointerEvents: isActive ? 'auto' : 'none' 
+            }}
+          >
+            <MediaItem item={item} isActive={isActive} transitionMs={transitionMs} />
+          </motion.div>
+        );
+      })}
     </div>
   );
 };
 
-const MediaItem = ({ item, isActive }: { item: HeroMedia, isActive: boolean }) => {
+const MediaItem = ({ item, isActive, transitionMs }: { item: HeroMedia, isActive: boolean, transitionMs: number }) => {
   const [hasError, setHasError] = useState(false);
+  const videoRef = useRef<HTMLVideoElement>(null);
+
+  useEffect(() => {
+    if (isActive && videoRef.current) {
+      videoRef.current.play().catch(() => {});
+    } else if (!isActive && videoRef.current) {
+      // フェードアウトが完了した頃に動画を一時停止し、リソースを節約する
+      const timer = setTimeout(() => {
+        if (videoRef.current) {
+          videoRef.current.pause();
+        }
+      }, transitionMs + 100);
+      return () => clearTimeout(timer);
+    }
+  }, [isActive, transitionMs]);
 
   if (item.type === 'image' || hasError) {
     return (
       <div 
-        className="w-full h-full bg-cover bg-center md:bg-cover bg-contain bg-no-repeat transition-all duration-1000"
+        className="w-full h-full bg-center md:bg-cover bg-contain bg-no-repeat"
         style={{ backgroundImage: `url(${item.posterUrl || item.url})` }}
       />
     );
@@ -95,16 +111,15 @@ const MediaItem = ({ item, isActive }: { item: HeroMedia, isActive: boolean }) =
   // ビデオの場合
   return (
     <video
-      className="w-full h-full object-contain md:object-cover transition-all duration-1000"
+      ref={videoRef}
+      className="w-full h-full object-contain md:object-cover"
       src={item.url}
       poster={item.posterUrl}
-      autoPlay={isActive}
       loop
       muted
       playsInline
       onError={() => setHasError(true)}
-      // アクティブじゃない時はリソースをあらかじめ読むだけにする
-      preload={isActive ? "auto" : "metadata"}
+      preload="auto"
     />
   );
 };


### PR DESCRIPTION
## 概要 / Overview
Codex（GPT-5.3）の提案「Luminous Ritual（光の儀式）」コンセプトに基づき、既存のPure White Luxuryデザインを維持しつつ、UI/UXのアップデートを実装しました。

## 変更内容 / Changes
このPRでは主に以下のフロントエンド改修およびメディア更新を行っています。

* **🎨 ビジュアルシステムの拡張と再定義**
  * `globals.css` に新色 `Air Gray`、`Pale Gold` 等を追加。本文フォントを `Sans-Serif` (細字) へ変更。
* **✨ 全画面「金粉の海」の実現**
  * 各セクション背景を透過（`bg-transparent`）し、背面のWebGLが常に煌めく空間を実現。
* **🎬 動画・画像の組み込みとシネマティックモーション強化**
  * ヒーローセクションで7つの動画をローテーション再生（5秒表示/2秒フェード）。
  * **(New)** スマホでのヒーロー動画切り替え時のカクつきを解消するため、DOMの再生成を防ぎ、スムーズな不透明度（Opacity）のみのクロスフェード実装に改修。
  * スマホなどモバイル閲覧時、ヒーローセクションの動画全体が見切れないよう `object-contain` にて表示最適化を実施。
  * Galleryセクションを「カード型グリッド（PC横3枚/スマホ横2枚）」に完全リニューアル。枠不足時は「Coming Soon」を表示。
* **💎 コンポーネントの Aura（オーラ）＆ 光沢化**
  * ギャラリーカード等の背景を変更し、クラス `shadow-aura` を適用。予約ボタンに `btn-sheen` 追加。

## 確認事項 / Checklist
- [x] 新規追加された動画・画像が正しく表示・ループ再生されること
- [x] スマホでヒーロー動画を見た際、切り替え時に黒い画面が挟まったりカクついたりせず、スムーズにクロスフェードすること
- [x] GalleryセクションがPCで3カラム・スマホで2カラムのカード型グリッドで表示されること
