### PR TITLE
fix(launch): close cast ops and today dashboard blockers

### DIFF
--- a/app/(cast)/cast/dashboard/page.tsx
+++ b/app/(cast)/cast/dashboard/page.tsx
@@ -20,6 +20,7 @@ import { getCastNotices } from '@/lib/actions/cast-notices';
 import { CheckinForm } from '@/components/features/today/CheckinForm';
 import { ReservationForm } from '@/components/features/today/ReservationForm';
 import { PageHeader, PageShell, SectionCard } from '@/components/ui/app-shell';
+import { getJstDateString } from '@/lib/date-utils';
 
 type CastDashboardRecentPost = {
   id: string;
@@ -33,6 +34,7 @@ type CastDashboardReservationRow = {
   id: string;
   visit_time: string;
   guest_name: string;
+  guest_count?: number | null;
   reservation_type: 'douhan' | 'reservation';
   note?: string | null;
 };
@@ -52,7 +54,7 @@ export default async function CastDashboardPage() {
     .limit(3);
 
   // 本日の出勤
-  const today = new Date().toISOString().split('T')[0];
+  const today = getJstDateString();
   const { data: todayShift } = await supabase
     .from('cast_schedules')
     .select('*')
@@ -106,6 +108,7 @@ export default async function CastDashboardPage() {
     id: r.id,
     visit_time: r.visit_time,
     guest_name: r.guest_name,
+    guest_count: r.guest_count ?? null,
     reservation_type: r.reservation_type,
     note: r.note ?? undefined,
   }));

--- a/app/(cast)/cast/register/page.tsx
+++ b/app/(cast)/cast/register/page.tsx
@@ -8,18 +8,62 @@ import { toast } from 'sonner';
 export default function CastRegisterPage() {
   const [isLoading, setIsLoading] = useState(false);
   const [isCompleted, setIsCompleted] = useState(false);
+  const [completedMessage, setCompletedMessage] = useState(
+    '本登録メールを送信しました。メール内のリンクから本登録を完了し、再設定したパスワードでログインしてください。'
+  );
+  const [feedback, setFeedback] = useState<{
+    type: 'error' | 'success';
+    title: string;
+    message: string;
+  } | null>(null);
+
+  const errorTitleMap: Record<string, string> = {
+    NO_MATCH: '照合失敗',
+    ALREADY_REGISTERED: '既登録',
+    AUTH_SIGNUP_FAILED: 'Auth作成失敗',
+    AUTH_USER_MISSING: 'Auth作成失敗',
+    ROLE_INSERT_FAILED: '権限付与失敗',
+    CAST_LINK_FAILED: 'キャスト紐付け失敗',
+    MATCH_LOOKUP_FAILED: '照合処理失敗',
+    UNEXPECTED: '想定外エラー',
+  };
 
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     setIsLoading(true);
+    setFeedback(null);
     const formData = new FormData(e.currentTarget);
 
-    const result = await castRegister(formData);
-    if (result.success) {
-      toast.success(result.message);
-      setIsCompleted(true);
-    } else {
-      toast.error(result.error);
+    try {
+      const result = await castRegister(formData);
+      if (result.success) {
+        const successMessage = result.message ?? 'アカウントを登録しました。確認メールをご確認ください。';
+        toast.success(successMessage);
+        setFeedback({
+          type: 'success',
+          title: '登録完了',
+          message: successMessage,
+        });
+        setCompletedMessage(successMessage);
+        setIsCompleted(true);
+      } else {
+        const errorMessage = result.error ?? '登録に失敗しました。時間をおいて再度お試しください。';
+        const title = errorTitleMap[result.code ?? 'UNEXPECTED'] ?? '登録失敗';
+        toast.error(errorMessage);
+        setFeedback({
+          type: 'error',
+          title,
+          message: errorMessage,
+        });
+      }
+    } catch {
+      const message = '想定外のエラーが発生しました。時間をおいて再度お試しください。';
+      toast.error(message);
+      setFeedback({
+        type: 'error',
+        title: '想定外エラー',
+        message,
+      });
     }
     setIsLoading(false);
   };
@@ -32,10 +76,7 @@ export default function CastRegisterPage() {
             <span className="text-gold text-2xl">✓</span>
           </div>
           <h2 className="font-serif text-xl tracking-widest text-[#171717] mb-4">登録完了</h2>
-          <p className="text-sm text-gray-500 leading-relaxed mb-8">
-            本登録メールを送信しました。<br />
-            メール内のリンクから本登録を完了し、<br />再設定したパスワードでログインしてください。
-          </p>
+          <p className="text-sm text-gray-500 leading-relaxed mb-8">{completedMessage}</p>
           <Link href="/cast/login" className="inline-block px-8 py-3 bg-[#171717] text-white text-xs tracking-[0.2em] uppercase rounded-xl hover:bg-gold transition-all">
             ログインへ戻る
           </Link>
@@ -60,6 +101,18 @@ export default function CastRegisterPage() {
         </div>
 
         <form onSubmit={handleSubmit} className="space-y-6">
+          {feedback && (
+            <div
+              className={`rounded-xl border px-4 py-3 text-sm ${
+                feedback.type === 'error'
+                  ? 'border-red-200 bg-red-50 text-red-700'
+                  : 'border-green-200 bg-green-50 text-green-700'
+              }`}
+            >
+              <p className="font-bold tracking-[0.12em] uppercase text-xs mb-1">{feedback.title}</p>
+              <p>{feedback.message}</p>
+            </div>
+          )}
 
           {/* 本名（Real Name） */}
           <div>

--- a/app/admin/(protected)/gallery/new/page.tsx
+++ b/app/admin/(protected)/gallery/new/page.tsx
@@ -1,5 +1,27 @@
-import { ContentForm } from '@/components/features/admin/ContentForm'
+import Link from 'next/link'
 
 export default function NewGalleryPage() {
-  return <ContentForm initialData={{ type: 'gallery' }} />
+  return (
+    <div className="max-w-2xl space-y-6">
+      <div>
+        <h1 className="text-2xl font-serif tracking-widest text-[#171717]">Gallery</h1>
+        <p className="text-sm text-gray-500 mt-2">ギャラリー管理は現在一時停止しています。</p>
+      </div>
+
+      <div className="rounded-sm border border-amber-200 bg-amber-50 p-6">
+        <p className="text-xs font-bold tracking-widest text-amber-800 uppercase">静的運用中</p>
+        <p className="mt-3 text-sm leading-7 text-amber-900">
+          公開サイトの <span className="font-bold">/gallery</span> は今回のリリースでは静的固定です。
+          この画面から追加しても公開には反映されないため、新規登録導線を停止しています。
+        </p>
+      </div>
+
+      <Link
+        href="/admin/gallery"
+        className="inline-flex items-center text-sm font-bold tracking-widest text-gray-500 transition-colors hover:text-[#171717]"
+      >
+        ギャラリー一覧へ戻る
+      </Link>
+    </div>
+  )
 }

--- a/app/admin/(protected)/gallery/page.tsx
+++ b/app/admin/(protected)/gallery/page.tsx
@@ -1,32 +1,28 @@
-import { getContents, deleteContent } from '@/lib/actions/contents'
-import Link from 'next/link'
-import { Plus, Edit2, Trash2 } from 'lucide-react'
-import { revalidatePath } from 'next/cache'
+import { getContents } from '@/lib/actions/contents'
+import { PauseCircle } from 'lucide-react'
 
 export default async function GalleryPage() {
   const contents = await getContents('gallery')
-
-  async function handleDelete(data: FormData) {
-    'use server'
-    const id = data.get('id') as string
-    await deleteContent(id)
-    revalidatePath('/admin/gallery')
-  }
 
   return (
     <div className="space-y-6">
       <div className="flex justify-between items-center">
         <div>
           <h1 className="text-2xl font-serif tracking-widest text-[#171717]">Gallery</h1>
-          <p className="text-sm text-gray-500 mt-2">店舗内装等のギャラリー画像の管理</p>
+          <p className="text-sm text-gray-500 mt-2">公開ギャラリー確認用の一覧です</p>
         </div>
-        <Link 
-          href="/admin/gallery/new" 
-          className="bg-[#171717] hover:bg-gold text-white px-4 py-2 rounded-sm text-sm font-bold tracking-widest flex items-center gap-2 transition-colors"
-        >
-          <Plus size={16} />
-          新規追加
-        </Link>
+        <div className="inline-flex items-center gap-2 rounded-sm border border-amber-200 bg-amber-50 px-4 py-2 text-sm font-bold tracking-widest text-amber-800">
+          <PauseCircle size={16} />
+          静的運用中
+        </div>
+      </div>
+
+      <div className="rounded-sm border border-amber-200 bg-amber-50 p-4">
+        <p className="text-xs font-bold tracking-widest text-amber-800 uppercase">公開反映は停止中です</p>
+        <p className="mt-2 text-sm leading-6 text-amber-900">
+          現在の公開 <span className="font-bold">/gallery</span> は静的データで固定運用しています。
+          この管理画面の登録内容は公開サイトへ反映されないため、追加・編集・削除は一時停止しています。
+        </p>
       </div>
 
       <div className="bg-white border border-gray-100 shadow-sm rounded-sm overflow-x-auto">
@@ -37,7 +33,7 @@ export default async function GalleryPage() {
               <th className="px-6 py-4 font-bold">Caption</th>
               <th className="px-6 py-4 font-bold">Category</th>
               <th className="px-6 py-4 font-bold">Status</th>
-              <th className="px-6 py-4 font-bold text-right">Actions</th>
+              <th className="px-6 py-4 font-bold text-right">Operation</th>
             </tr>
           </thead>
           <tbody className="divide-y divide-gray-50">
@@ -66,20 +62,9 @@ export default async function GalleryPage() {
                   </span>
                 </td>
                 <td className="px-6 py-4 text-right">
-                  <div className="flex justify-end items-center gap-2">
-                    <button className="p-2 text-gray-400 hover:text-[#171717] transition-colors rounded hover:bg-gray-100">
-                      <Edit2 size={16} />
-                    </button>
-                    <form action={handleDelete}>
-                      <input type="hidden" name="id" value={content.id} />
-                      <button 
-                        type="submit"
-                        className="p-2 text-gray-400 hover:text-red-600 transition-colors rounded hover:bg-red-50"
-                      >
-                        <Trash2 size={16} />
-                      </button>
-                    </form>
-                  </div>
+                  <span className="inline-flex items-center rounded bg-gray-100 px-2 py-1 text-xs font-bold tracking-wider text-gray-500">
+                    停止中
+                  </span>
                 </td>
               </tr>
             ))}

--- a/app/admin/(protected)/layout.tsx
+++ b/app/admin/(protected)/layout.tsx
@@ -13,8 +13,21 @@ export default async function Layout({ children }: { children: React.ReactNode }
       .from('profiles')
       .select('role')
       .eq('id', user.id)
-      .single();
-    if (profile) role = profile.role;
+      .maybeSingle();
+
+    if (profile?.role) {
+      role = profile.role;
+    } else {
+      const { data: userRole } = await supabase
+        .from('user_roles')
+        .select('role')
+        .eq('user_id', user.id)
+        .maybeSingle();
+
+      if (userRole?.role) {
+        role = userRole.role;
+      }
+    }
   }
 
 

--- a/app/admin/(protected)/today/page.tsx
+++ b/app/admin/(protected)/today/page.tsx
@@ -2,14 +2,13 @@ import { getTodayDashboard } from '@/lib/actions/today'
 import { getCasts } from '@/lib/actions/casts'
 import { TodayDashboard } from '@/components/features/today/TodayDashboard'
 import { PageHeader, PageShell } from '@/components/ui/app-shell'
+import { getJstDateLabel, getJstDateString } from '@/lib/date-utils'
 
 export const dynamic = 'force-dynamic'
 
 export default async function TodayPage() {
-  const today = new Date().toISOString().split('T')[0]
-  const d = new Date()
-  const weekdays = ['日', '月', '火', '水', '木', '金', '土']
-  const dateLabel = `${d.getMonth() + 1}月${d.getDate()}日（${weekdays[d.getDay()]}）`
+  const today = getJstDateString()
+  const dateLabel = getJstDateLabel()
 
   const [data, castsRaw] = await Promise.all([
     getTodayDashboard(today),

--- a/app/api/cron/daily-checkin-reminder/route.ts
+++ b/app/api/cron/daily-checkin-reminder/route.ts
@@ -5,9 +5,9 @@ import { Resend } from 'resend'
 /**
  * 本日確認 自動メール送信 Cron
  *
- * Vercel Cron: 0 7 * * 1-6  (UTC 07:00 = JST 16:00, 月〜土)
+ * Vercel Cron: 0 8 * * 1-6  (UTC 08:00 = JST 17:00, 月〜土)
  * vercel.json に以下を追記すること
- * { "path": "/api/cron/daily-checkin-reminder", "schedule": "0 7 * * 1-6" }
+ * { "path": "/api/cron/daily-checkin-reminder", "schedule": "0 8 * * 1-6" }
  *
  * 処理フロー:
  * 1. JST 日曜かどうかを確認し、日曜なら早期終了

--- a/components/features/admin/CastForm.tsx
+++ b/components/features/admin/CastForm.tsx
@@ -94,7 +94,10 @@ export function CastForm({ initialData }: { initialData?: Cast }) {
         ? await updateCast(initialData.id, formData)
         : await createCast(formData)
       if (result.error) showToast(result.error, 'error')
-      else router.push('/admin/human-resources')
+      else {
+        router.push('/admin/human-resources')
+        router.refresh()
+      }
     } catch (err: unknown) {
       const error = err as Error;
       showToast(error.message, 'error')
@@ -120,7 +123,7 @@ export function CastForm({ initialData }: { initialData?: Cast }) {
       const { blob, dataUrl } = await resizeImage(file, 1200, 0.8)
       setImagePreview(dataUrl)
       setCompressedImage(blob)
-    } catch (error) {
+    } catch {
       showToast('画像の処理に失敗しました。別の画像をお試しください。', 'error')
       e.target.value = ''
       setImagePreview(null)
@@ -247,7 +250,8 @@ export function CastForm({ initialData }: { initialData?: Cast }) {
             </div>
             <p className="text-xs text-amber-700 leading-relaxed">
               本名・生年月日はサイトおよびキャストダッシュボードには一切表示されません。<br />
-              同じ源氏名のキャストが過去・将来に存在する場合の本人特定と、キャストアカウントの発行に使用します。
+              同じ源氏名のキャストが過去・将来に存在する場合の本人特定と、本人自己登録時の照合に使用します。<br />
+              管理画面からログインアカウントは発行されません。登録後は本人が <span className="font-bold">/cast/register</span> から自己登録します。
             </p>
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
               <div>

--- a/components/features/today/ReservationForm.tsx
+++ b/components/features/today/ReservationForm.tsx
@@ -10,6 +10,7 @@ type Reservation = {
   id: string
   visit_time: string
   guest_name: string
+  guest_count?: number | null
   reservation_type: string
   note?: string
 }
@@ -54,6 +55,9 @@ export function ReservationForm({ reservations }: { reservations: Reservation[] 
               <Clock size={14} className="text-gold shrink-0" />
               <span className="text-sm font-bold text-gold w-12 shrink-0">{r.visit_time.substring(0, 5)}</span>
               <span className="text-sm text-gray-700">{r.guest_name}様</span>
+              {r.guest_count ? (
+                <span className="text-xs text-gray-500 shrink-0">{r.guest_count}名</span>
+              ) : null}
               <span className={`text-xs px-2 py-0.5 rounded-full font-bold ${r.reservation_type === 'douhan' ? 'bg-pink-100 text-pink-700' : 'bg-blue-100 text-blue-700'}`}>
                 {r.reservation_type === 'douhan' ? '同伴' : '来店予定'}
               </span>
@@ -79,6 +83,17 @@ export function ReservationForm({ reservations }: { reservations: Reservation[] 
             <p className="text-xs text-gray-300 mt-1">「様」はつけずに入力してください</p>
           </div>
           <div>
+            <label className="block text-xs text-gray-500 mb-1">人数</label>
+            <input
+              name="guest_count"
+              type="number"
+              min="1"
+              inputMode="numeric"
+              placeholder="2"
+              className={inputClass}
+            />
+          </div>
+          <div>
             <label className="block text-xs text-gray-500 mb-1">種別 *</label>
             <select name="reservation_type" required className={inputClass}>
               <option value="">選択してください</option>
@@ -88,7 +103,7 @@ export function ReservationForm({ reservations }: { reservations: Reservation[] 
           </div>
           <div>
             <label className="block text-xs text-gray-500 mb-1">メモ（任意）</label>
-            <input name="note" type="text" placeholder="人数、テーブルなど" className={inputClass} />
+            <input name="note" type="text" placeholder="テーブル、備考など" className={inputClass} />
           </div>
           <div className="flex gap-2 pt-1">
             <button

--- a/components/features/today/TodayDashboard.tsx
+++ b/components/features/today/TodayDashboard.tsx
@@ -14,8 +14,7 @@ import {
   deleteStaffAttendance,
   generateLineText,
 } from '@/lib/actions/today'
-import { getCasts } from '@/lib/actions/casts'
-import { Copy, Plus, Trash2, Users, Truck, Star, ChevronRight, AlertTriangle, Calendar, Clock } from 'lucide-react'
+import { Copy, Plus, Trash2, Users, Star, ChevronRight, AlertTriangle, Calendar, Clock } from 'lucide-react'
 import { useRouter } from 'next/navigation'
 
 type Cast = { id: string; stage_name?: string }
@@ -331,6 +330,9 @@ export function TodayDashboard({ data, casts }: Props) {
                 <span className="text-sm font-bold text-gold w-12 shrink-0">{r.visit_time.substring(0, 5)}</span>
                 <span className="text-sm font-bold">{r.stage_name}</span>
                 <span className="text-sm text-gray-600">{r.guest_name}様</span>
+                {r.guest_count ? (
+                  <span className="text-xs text-gray-500 shrink-0">{r.guest_count}名</span>
+                ) : null}
                 <span className={`text-xs px-2 py-0.5 rounded-full font-bold ml-auto shrink-0 ${r.reservation_type === 'douhan' ? 'bg-pink-100 text-pink-700' : 'bg-blue-100 text-blue-700'}`}>
                   {r.reservation_type === 'douhan' ? '同伴' : '来店予定'}
                 </span>
@@ -352,7 +354,7 @@ export function TodayDashboard({ data, casts }: Props) {
                   <span className="text-sm font-bold text-red-600">{c.stage_name}</span>
                   {isMailSent ? (
                     <span className="text-xs bg-blue-50 text-blue-600 border border-blue-200 px-2 py-0.5 rounded-full font-bold flex items-center gap-1">
-                      📧 16:00 メール済み
+                      📧 17:00 メール済み
                     </span>
                   ) : (
                     <span className="text-xs text-gray-400">未連絡</span>

--- a/components/layouts/AdminLayout.tsx
+++ b/components/layouts/AdminLayout.tsx
@@ -12,7 +12,6 @@ import {
   MessageSquare,
   FileText,
   LogOut,
-  UserCheck,
   Briefcase,
   Menu,
   ChevronRight,
@@ -248,7 +247,6 @@ export function AdminLayout({
           {BOTTOM_TAB_ITEMS.map((item) => {
             const isActive = pathname.startsWith(item.href);
             const Icon = item.icon;
-            const isInbox = item.href === '/admin/applications';
             return (
               <Link
                 key={item.href}

--- a/components/seo/LocalBusinessSchema.tsx
+++ b/components/seo/LocalBusinessSchema.tsx
@@ -47,8 +47,7 @@ export function LocalBusinessSchema() {
     },
     "sameAs": [
       "https://www.instagram.com/kannai_club_animo/",
-      "https://line.me/R/ti/p/@animo_kannai",
-      "https://maps.app.goo.gl/placeholder_for_animo"
+      "https://line.me/R/ti/p/@animo_kannai"
     ],
     "hasMap": "https://maps.google.com/maps?q=%E7%A5%9E%E5%A5%88%E5%B7%9D%E7%9C%8C%E6%A8%AA%E6%B5%9C%E5%B8%82%E4%B8%AD%E5%8C%BA%E7%9B%B8%E7%94%9F%E7%94%BA3%E4%B8%81%E7%9B%AE53+%E3%82%B0%E3%83%A9%E3%83%B3%E3%83%89%E3%83%91%E3%83%BC%E3%82%AF%E3%83%93%E3%83%AB"
   };

--- a/lib/actions/cast-auth.ts
+++ b/lib/actions/cast-auth.ts
@@ -1,6 +1,7 @@
 'use server';
 
 import { createClient } from '@/lib/supabase/server';
+import { createServiceClient } from '@/lib/supabase/service';
 import { redirect } from 'next/navigation';
 import { revalidatePath } from 'next/cache';
 
@@ -46,68 +47,138 @@ export async function castRegister(formData: FormData) {
   }
 
   const supabase = await createClient();
+  const serviceRoleClient = createServiceClient();
 
-  // 本名 + 生年月日の完全一致でキャストを特定
-  const { data: privateInfo } = await supabase
-    .from('cast_private_info')
-    .select('cast_id, casts!inner(id, stage_name, auth_user_id)')
-    .eq('real_name', realName)
-    .eq('date_of_birth', dateOfBirth)
-    .maybeSingle();
+  try {
+    // 個人情報テーブルは匿名ユーザーに公開せず、サーバー側のみで照合する。
+    const { data: privateInfo, error: privateInfoError } = await serviceRoleClient
+      .from('cast_private_info')
+      .select('cast_id, casts!inner(id, stage_name, auth_user_id)')
+      .eq('real_name', realName)
+      .eq('date_of_birth', dateOfBirth)
+      .maybeSingle();
 
-  if (!privateInfo) {
-    return {
-      success: false,
-      error: '入力された本名・生年月日に一致するキャスト情報が見つかりませんでした。正しく入力されているか、または担当者にお問い合わせください。',
+    if (privateInfoError) {
+      return {
+        success: false,
+        error: '本人確認情報の照合に失敗しました。時間をおいて再度お試しください。',
+        code: 'MATCH_LOOKUP_FAILED',
+      };
+    }
+
+    if (!privateInfo) {
+      return {
+        success: false,
+        error: '入力された本名・生年月日に一致するキャスト情報が見つかりませんでした。正しく入力されているか、または担当者にお問い合わせください。',
+        code: 'NO_MATCH',
+      };
+    }
+
+    const castRecord = privateInfo.casts as unknown as {
+      id: string;
+      stage_name: string;
+      auth_user_id: string | null;
     };
-  }
 
-  // TypeScriptの型安全のためにキャスト
-  const castRecord = privateInfo.casts as unknown as { id: string; stage_name: string; auth_user_id: string | null };
+    if (castRecord.auth_user_id) {
+      return {
+        success: false,
+        error: 'このキャストのアカウントはすでに登録済みです。担当者にお問い合わせください。',
+        code: 'ALREADY_REGISTERED',
+      };
+    }
 
-  if (castRecord.auth_user_id) {
-    return {
-      success: false,
-      error: 'このキャストのアカウントはすでに登録済みです。担当者にお問い合わせください。',
-    };
-  }
+    const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://animo-lake.vercel.app';
+    const { data, error } = await supabase.auth.signUp({
+      email,
+      password,
+      options: {
+        emailRedirectTo: `${siteUrl}/cast/reset-password`,
+      },
+    });
 
-  // Supabase Auth にアカウント登録
-  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://animo-lake.vercel.app';
-  const { data, error } = await supabase.auth.signUp({
-    email,
-    password,
-    options: {
-      emailRedirectTo: `${siteUrl}/cast/reset-password`,
-    },
-  });
+    let authUser = data.user;
+    let usedRateLimitFallback = false;
 
-  if (error) {
-    return { success: false, error: error.message };
-  }
+    if (error) {
+      if (error.message.toLowerCase().includes('email rate limit exceeded')) {
+        const { data: fallbackData, error: fallbackError } =
+          await serviceRoleClient.auth.admin.createUser({
+            email,
+            password,
+            email_confirm: true,
+          });
 
-  if (data.user) {
-    // RLSをバイパスするため、ここからサービスロールを使用（サインアップ直後はまだログイン状態ではないため）
-    const { createServiceClient } = await import('@/lib/supabase/service');
-    const serviceRoleClient = createServiceClient();
+        if (fallbackError) {
+          return {
+            success: false,
+            error: `アカウント作成に失敗しました: ${fallbackError.message}`,
+            code: 'AUTH_SIGNUP_FAILED',
+          };
+        }
 
-    // user_roles に cast ロールを追加
-    await serviceRoleClient.from('user_roles').insert({
-      user_id: data.user.id,
+        authUser = fallbackData.user;
+        usedRateLimitFallback = true;
+      } else {
+        return {
+          success: false,
+          error: `アカウント作成に失敗しました: ${error.message}`,
+          code: 'AUTH_SIGNUP_FAILED',
+        };
+      }
+    }
+
+    if (!authUser) {
+      return {
+        success: false,
+        error: 'アカウント作成の応答が不正でした。時間をおいて再度お試しください。',
+        code: 'AUTH_USER_MISSING',
+      };
+    }
+
+    const { error: roleError } = await serviceRoleClient.from('user_roles').insert({
+      user_id: authUser.id,
       role: 'cast',
     });
 
-    // casts テーブルの auth_user_id を自動紐付け
-    await serviceRoleClient
-      .from('casts')
-      .update({ auth_user_id: data.user.id })
-      .eq('id', castRecord.id);
-  }
+    if (roleError && roleError.code !== '23505') {
+      return {
+        success: false,
+        error: 'アカウント作成後の権限付与に失敗しました。担当者にお問い合わせください。',
+        code: 'ROLE_INSERT_FAILED',
+      };
+    }
 
-  return {
-    success: true,
-    message: `アカウントを登録しました。確認メールをご確認の上、ログインしてください。`,
-  };
+    const { error: castUpdateError } = await serviceRoleClient
+      .from('casts')
+      .update({ auth_user_id: authUser.id })
+      .eq('id', castRecord.id)
+      .is('auth_user_id', null);
+
+    if (castUpdateError) {
+      return {
+        success: false,
+        error: 'アカウント作成後のキャスト紐付けに失敗しました。担当者にお問い合わせください。',
+        code: 'CAST_LINK_FAILED',
+      };
+    }
+
+    revalidatePath('/cast/register');
+
+    return {
+      success: true,
+      message: usedRateLimitFallback
+        ? 'アカウントを登録しました。メール送信上限のため確認メールは送信できませんでしたが、このままログインできます。'
+        : 'アカウントを登録しました。確認メールをご確認の上、ログインしてください。',
+      code: 'SUCCESS',
+    };
+  } catch {
+    return {
+      success: false,
+      error: '想定外のエラーが発生しました。時間をおいて再度お試しください。',
+      code: 'UNEXPECTED',
+    };
+  }
 }
 
 

--- a/lib/actions/today.ts
+++ b/lib/actions/today.ts
@@ -1,6 +1,8 @@
 'use server'
 
 import { createClient } from '@/lib/supabase/server'
+import { createServiceClient } from '@/lib/supabase/service'
+import { getJstDateString } from '@/lib/date-utils'
 import { revalidatePath } from 'next/cache'
 import { StaffSlave } from './staffs'
 import { getAnalyticsSummary } from './analytics'
@@ -32,6 +34,7 @@ export type TodayReservation = {
   stage_name: string
   visit_time: string
   guest_name: string
+  guest_count?: number | null
   reservation_type: 'douhan' | 'reservation'
   note?: string
 }
@@ -87,8 +90,8 @@ export type TodayDashboardData = {
 // 本日の全データ取得
 // ==========================================
 export async function getTodayDashboard(dateStr?: string): Promise<TodayDashboardData> {
-  const supabase = await createClient()
-  const today = dateStr || new Date().toISOString().split('T')[0]
+  const supabase = createServiceClient()
+  const today = dateStr || getJstDateString()
 
   // 本日の承認済みシフトを取得
   const { data: shiftsRaw } = await supabase
@@ -130,7 +133,7 @@ export async function getTodayDashboard(dateStr?: string): Promise<TodayDashboar
   // 来店予定
   const { data: reservationsRaw } = await supabase
     .from('daily_reservations')
-    .select('id, cast_id, visit_time, guest_name, reservation_type, note, casts(stage_name)')
+    .select('id, cast_id, visit_time, guest_name, guest_count, reservation_type, note, casts(stage_name)')
     .eq('reservation_date', today)
     .order('visit_time')
 
@@ -142,6 +145,7 @@ export async function getTodayDashboard(dateStr?: string): Promise<TodayDashboar
       stage_name: cast?.stage_name || '不明',
       visit_time: r.visit_time,
       guest_name: r.guest_name,
+      guest_count: r.guest_count,
       reservation_type: r.reservation_type,
       note: r.note,
     }
@@ -324,7 +328,8 @@ export async function generateLineText(data: TodayDashboardData): Promise<string
     lines.push('来店予定')
     for (const r of data.reservations) {
       const typeLabel = r.reservation_type === 'douhan' ? '同伴' : '来店予定'
-      lines.push(`${r.visit_time.substring(0, 5)}　${r.stage_name}　${r.guest_name}様　${typeLabel}`)
+      const guestCountLabel = r.guest_count ? `　${r.guest_count}名` : ''
+      lines.push(`${r.visit_time.substring(0, 5)}　${r.stage_name}　${r.guest_name}様${guestCountLabel}　${typeLabel}`)
     }
   }
 
@@ -440,7 +445,7 @@ export async function submitCheckin(formData: FormData) {
     .single()
   if (!cast) return { error: 'キャスト情報が見つかりません' }
 
-  const today = new Date().toISOString().split('T')[0]
+  const today = getJstDateString()
   const { error } = await supabase.from('daily_checkins').upsert({
     cast_id: cast.id,
     checkin_date: today,
@@ -471,12 +476,22 @@ export async function addReservation(formData: FormData) {
     .single()
   if (!cast) return { error: 'キャスト情報が見つかりません' }
 
-  const today = new Date().toISOString().split('T')[0]
+  const today = getJstDateString()
+  const guestCountValue = formData.get('guest_count')
+  const guestCount = typeof guestCountValue === 'string' && guestCountValue.trim() !== ''
+    ? Number.parseInt(guestCountValue, 10)
+    : null
+
+  if (guestCount !== null && (!Number.isInteger(guestCount) || guestCount <= 0)) {
+    return { error: '人数は1以上の整数で入力してください' }
+  }
+
   const { error } = await supabase.from('daily_reservations').insert({
     cast_id: cast.id,
     reservation_date: today,
     visit_time: formData.get('visit_time') as string,
     guest_name: formData.get('guest_name') as string,
+    guest_count: guestCount,
     reservation_type: formData.get('reservation_type') as string,
     note: (formData.get('note') as string) || null,
   })
@@ -505,7 +520,7 @@ export async function getCastTodayReservations() {
     .single()
   if (!cast) return []
 
-  const today = new Date().toISOString().split('T')[0]
+  const today = getJstDateString()
   const { data } = await supabase
     .from('daily_reservations')
     .select('*')
@@ -528,7 +543,7 @@ export async function getCastTodayCheckin() {
     .single()
   if (!cast) return null
 
-  const today = new Date().toISOString().split('T')[0]
+  const today = getJstDateString()
   const { data } = await supabase
     .from('daily_checkins')
     .select('*')

--- a/lib/date-utils.ts
+++ b/lib/date-utils.ts
@@ -1,0 +1,38 @@
+const JST_TIME_ZONE = 'Asia/Tokyo'
+
+function getPartMap(
+  date: Date,
+  options: Intl.DateTimeFormatOptions
+): Record<string, string> {
+  return new Intl.DateTimeFormat('en-US', {
+    timeZone: JST_TIME_ZONE,
+    ...options,
+  })
+    .formatToParts(date)
+    .reduce<Record<string, string>>((acc, part) => {
+      if (part.type !== 'literal') {
+        acc[part.type] = part.value
+      }
+      return acc
+    }, {})
+}
+
+export function getJstDateString(date: Date = new Date()): string {
+  const parts = getPartMap(date, {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  })
+
+  return `${parts.year}-${parts.month}-${parts.day}`
+}
+
+export function getJstDateLabel(date: Date = new Date()): string {
+  const parts = getPartMap(date, {
+    month: 'numeric',
+    day: 'numeric',
+    weekday: 'short',
+  })
+
+  return `${parts.month}月${parts.day}日（${parts.weekday}）`
+}

--- a/lib/supabase/middleware.ts
+++ b/lib/supabase/middleware.ts
@@ -1,6 +1,37 @@
 import { createServerClient } from '@supabase/ssr'
 import { NextResponse, type NextRequest } from 'next/server'
 
+const ALLOWED_ADMIN_ROLES = new Set(['owner', 'manager', 'admin'])
+
+async function getAppRole(
+  supabase: ReturnType<typeof createServerClient>,
+  userId: string
+) {
+  const { data: profile } = await supabase
+    .from('profiles')
+    .select('role')
+    .eq('id', userId)
+    .maybeSingle()
+
+  if (profile?.role) {
+    return profile.role
+  }
+
+  const { data: userRole } = await supabase
+    .from('user_roles')
+    .select('role')
+    .eq('user_id', userId)
+    .maybeSingle()
+
+  return userRole?.role ?? null
+}
+
+function redirectToSafeDestination(request: NextRequest, role: string | null) {
+  const url = request.nextUrl.clone()
+  url.pathname = role === 'cast' ? '/cast/dashboard' : '/'
+  return NextResponse.redirect(url)
+}
+
 export async function updateSession(request: NextRequest) {
   let supabaseResponse = NextResponse.next({
     request,
@@ -39,9 +70,10 @@ export async function updateSession(request: NextRequest) {
   const {
     data: { user },
   } = await supabase.auth.getUser()
+  const pathname = request.nextUrl.pathname
 
   // Protect /admin routes
-  if (request.nextUrl.pathname.startsWith('/admin') && !request.nextUrl.pathname.startsWith('/admin/login')) {
+  if (pathname.startsWith('/admin') && !pathname.startsWith('/admin/login')) {
     if (!user) {
       const url = request.nextUrl.clone()
       url.pathname = '/admin/login'
@@ -49,33 +81,27 @@ export async function updateSession(request: NextRequest) {
     }
 
     // Redirect /admin directly to /admin/dashboard
-    if (request.nextUrl.pathname === '/admin') {
+    if (pathname === '/admin') {
       const url = request.nextUrl.clone()
       url.pathname = '/admin/dashboard'
       return NextResponse.redirect(url)
     }
 
-    // Role-based Access Control for restricted routes
-    if (
-      request.nextUrl.pathname.startsWith('/admin/settings') ||
-      request.nextUrl.pathname.startsWith('/admin/staffs')
-    ) {
-      const { data: profile } = await supabase
-        .from('profiles')
-        .select('role')
-        .eq('id', user.id)
-        .single()
-      
-      if (!profile || (profile.role !== 'owner' && profile.role !== 'manager')) {
-        const url = request.nextUrl.clone()
-        url.pathname = '/admin/dashboard'
-        return NextResponse.redirect(url)
-      }
+    const role = await getAppRole(supabase, user.id)
+
+    if (!role || !ALLOWED_ADMIN_ROLES.has(role)) {
+      return redirectToSafeDestination(request, role)
     }
   }
 
   // Redirect logged in users away from login page
-  if (request.nextUrl.pathname.startsWith('/admin/login') && user) {
+  if (pathname.startsWith('/admin/login') && user) {
+    const role = await getAppRole(supabase, user.id)
+
+    if (!role || !ALLOWED_ADMIN_ROLES.has(role)) {
+      return supabaseResponse
+    }
+
     const url = request.nextUrl.clone()
     url.pathname = '/admin/dashboard'
     return NextResponse.redirect(url)

--- a/supabase/migrations/20260401090000_add_daily_reservations_guest_count.sql
+++ b/supabase/migrations/20260401090000_add_daily_reservations_guest_count.sql
@@ -1,0 +1,5 @@
+ALTER TABLE public.daily_reservations
+ADD COLUMN IF NOT EXISTS guest_count integer
+CHECK (guest_count IS NULL OR guest_count > 0);
+
+COMMENT ON COLUMN public.daily_reservations.guest_count IS '来店予定の人数';

--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,7 @@
   "crons": [
     {
       "path": "/api/cron/daily-checkin-reminder",
-      "schedule": "0 7 * * 1-6"
+      "schedule": "0 8 * * 1-6"
     },
     {
       "path": "/api/automation/birthday",


### PR DESCRIPTION
Overview

Close the remaining launch blockers for Club Animo by stabilizing cast self-registration, tightening admin access behavior, aligning today/reservation flows to JST, adding guest_count support end-to-end, correcting the daily reminder schedule, removing placeholder structured data, and preventing gallery admin misoperation during static-mode release.

Scope

- cast self-registration and cast dashboard reachability
- protected admin behavior tightening
- today dashboard / reservation / guest_count / JST alignment
- daily reminder schedule correction
- gallery admin static-mode safety
- placeholder structured data cleanup

Included files

- lib/supabase/middleware.ts
- app/admin/(protected)/layout.tsx
- components/features/admin/CastForm.tsx
- supabase/migrations/20260401090000_add_daily_reservations_guest_count.sql
- lib/actions/today.ts
- components/features/today/ReservationForm.tsx
- components/features/today/TodayDashboard.tsx
- app/(cast)/cast/dashboard/page.tsx
- app/api/cron/daily-checkin-reminder/route.ts
- vercel.json
- components/seo/LocalBusinessSchema.tsx
- app/admin/(protected)/gallery/page.tsx
- app/admin/(protected)/gallery/new/page.tsx
- components/layouts/AdminLayout.tsx
- lib/date-utils.ts
- lib/actions/cast-auth.ts
- app/(cast)/cast/register/page.tsx
- app/admin/(protected)/today/page.tsx

Notes

- unrelated media / generated / temp / seed/init changes are intentionally excluded
- this PR is scoped only to the agreed launch blockers