### PR TITLE
feat(admin-auth): add desktop/mobile auth pages

### DIFF
--- a/app/admin/forgot-password/page.tsx
+++ b/app/admin/forgot-password/page.tsx
@@ -1,0 +1,145 @@
+'use client'
+
+import React, { useActionState } from 'react'
+import Link from 'next/link'
+import { adminForgotPasswordAction } from '@/lib/actions/admin-auth'
+
+function MailIcon() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="18"
+      height="18"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.8"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M4 4h16v16H4z" />
+      <path d="m22 6-10 7L2 6" />
+    </svg>
+  )
+}
+
+export default function AdminForgotPasswordPage() {
+  const [state, formAction, isPending] = useActionState(adminForgotPasswordAction, null)
+
+  return (
+    <div className="min-h-screen bg-black flex items-center justify-center p-6">
+      <div
+        className="w-full max-w-[448px] rounded-[16px] p-1"
+        style={{
+          background:
+            'linear-gradient(131deg, rgb(223,189,105) 0%, rgb(146,111,52) 100%)',
+          boxShadow: '0 0 48px rgba(223,189,105,0.25)',
+        }}
+      >
+        <div
+          className="w-full rounded-[14px] p-10"
+          style={{
+            background:
+              'linear-gradient(131deg, rgb(24,24,27) 0%, rgb(39,39,42) 50%, rgb(24,24,27) 100%)',
+            boxShadow: '0px 25px 50px 0px rgba(0,0,0,0.25)',
+          }}
+        >
+          <div className="text-center mb-6">
+            <p
+              className="text-white text-sm tracking-[0.3em] uppercase font-light mb-1"
+              style={{ fontFamily: 'var(--font-serif, serif)' }}
+            >
+              CLUB ANIMO
+            </p>
+            <h1 className="text-white text-2xl font-bold tracking-[0.2em] uppercase mb-4">
+              ANIMO CMS
+            </h1>
+            <p
+              className="text-lg font-bold"
+              style={{
+                background:
+                  'linear-gradient(90deg, rgb(223,189,105) 0%, rgb(146,111,52) 100%)',
+                WebkitBackgroundClip: 'text',
+                backgroundClip: 'text',
+                color: 'transparent',
+              }}
+            >
+              パスワードをリセット
+            </p>
+          </div>
+
+          <p className="text-sm text-center mb-8" style={{ color: '#9f9fa9' }}>
+            登録されたメールアドレスを入力してください。<br />
+            パスワードリセット用のリンクをお送りします。
+          </p>
+
+          <form action={formAction} className="space-y-4">
+            <div>
+              <label className="block text-sm mb-2" style={{ color: '#9f9fa9' }}>
+                メールアドレス
+              </label>
+              <div className="relative">
+                <span
+                  className="absolute left-3 top-1/2 -translate-y-1/2"
+                  style={{ color: '#71717b' }}
+                  aria-hidden
+                >
+                  <MailIcon />
+                </span>
+                <input
+                  name="email"
+                  type="email"
+                  required
+                  autoComplete="email"
+                  className="w-full rounded-[10px] pl-11 pr-4 py-3 text-base text-white placeholder-[#71717b] focus:outline-none focus-visible:ring-2 focus-visible:ring-[#dfbd69]/25"
+                  placeholder="example@email.com"
+                  style={{ background: '#27272a', border: '0.556px solid #3f3f47' }}
+                />
+              </div>
+            </div>
+
+            {(state?.error || state?.message) && (
+              <p
+                className="text-xs text-center rounded-lg py-2.5 px-4"
+                style={{
+                  color: state?.error ? '#f87171' : '#9f9fa9',
+                  background: state?.error ? 'rgba(239,68,68,0.1)' : 'rgba(63,63,71,0.35)',
+                }}
+              >
+                {state?.error ?? state?.message}
+              </p>
+            )}
+
+            <button
+              type="submit"
+              disabled={isPending}
+              className="w-full h-[48px] rounded-[10px] text-base font-semibold transition-opacity disabled:opacity-60"
+              style={{
+                background:
+                  'linear-gradient(90deg, rgb(223,189,105) 0%, rgb(146,111,52) 100%)',
+                color: '#18181b',
+              }}
+            >
+              {isPending ? '送信中...' : 'リセットリンクを送信'}
+            </button>
+
+            <Link
+              href="/admin/login"
+              className="block w-full h-[49px] rounded-[10px] border text-center leading-[49px] text-base"
+              style={{ borderColor: '#3f3f47', color: '#d4d4d8' }}
+            >
+              ← ログイン画面に戻る
+            </Link>
+          </form>
+
+          <div className="mt-4 text-center">
+            <Link href="/admin/m/forgot-password" className="text-sm hover:underline" style={{ color: '#9f9fa9' }}>
+              モバイル版はこちら
+            </Link>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+

--- a/app/admin/login/page.tsx
+++ b/app/admin/login/page.tsx
@@ -1,55 +1,180 @@
 'use client';
 
-import React, { useActionState } from 'react';
+import React, { useActionState, useState } from 'react';
+import Link from 'next/link';
 import { login } from '@/lib/actions/auth';
-import { Button } from '@/components/ui/Button';
+
+function EyeIcon({ open }: { open: boolean }) {
+  return open ? (
+    <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" />
+      <circle cx="12" cy="12" r="3" />
+    </svg>
+  ) : (
+    <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94" />
+      <path d="M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19" />
+      <line x1="1" y1="1" x2="23" y2="23" />
+    </svg>
+  );
+}
 
 export default function LoginPage() {
   const [state, formAction, isPending] = useActionState(login, null);
+  const [showPassword, setShowPassword] = useState(false);
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-[var(--color-gray-light)] p-6">
-      <div className="w-full max-w-sm bg-white border border-gray-100 shadow-sm p-8 rounded-sm">
+    <div className="min-h-screen bg-black flex items-center justify-center p-6">
+      {/* Card (Figma-like) */}
+      <div
+        className="w-full max-w-[448px] rounded-[16px] p-1"
+        style={{
+          background:
+            'linear-gradient(128deg, rgb(223,189,105) 0%, rgb(146,111,52) 100%)',
+          boxShadow: '0 0 48px rgba(223,189,105,0.25)',
+        }}
+      >
+        <div
+          className="w-full rounded-[14px] p-10"
+          style={{
+            background:
+              'linear-gradient(128deg, rgb(24,24,27) 0%, rgb(39,39,42) 50%, rgb(24,24,27) 100%)',
+            boxShadow:
+              '0px 25px 50px 0px rgba(0,0,0,0.25)',
+          }}
+        >
+        {/* Header */}
         <div className="text-center mb-8">
-          <h1 className="font-serif tracking-widest text-[#171717] text-2xl uppercase mb-2">Club Animo</h1>
-          <p className="text-xs text-gray-500 tracking-widest uppercase">Admin System</p>
+          <p
+            className="text-white text-sm tracking-[0.3em] uppercase font-light mb-1"
+            style={{ fontFamily: 'var(--font-serif, serif)' }}
+          >
+            CLUB ANIMO
+          </p>
+          <h1
+            className="text-white text-3xl font-bold tracking-[0.2em] uppercase mb-5"
+          >
+            ANIMO CMS
+          </h1>
+          <p
+            className="text-sm font-semibold tracking-wide"
+            style={{ color: '#C9A84C' }}
+          >
+            Welcome to Animo Dashboard
+          </p>
         </div>
 
-        <form action={formAction} className="space-y-6">
+        {/* Form */}
+        <form action={formAction} className="space-y-5">
+          {/* Login ID */}
           <div>
-            <label className="block text-xs font-bold tracking-widest text-gray-500 uppercase mb-2">Email</label>
-            <input 
+            <label
+              htmlFor="admin-email"
+              className="block text-sm mb-2"
+              style={{ color: '#9f9fa9' }}
+            >
+              ログインID
+            </label>
+            <input
+              id="admin-email"
               name="email"
-              type="email" 
+              type="email"
               required
-              className="w-full border-b-2 border-gray-200 py-3 min-h-[48px] text-sm focus:outline-none focus:border-gold focus:ring-0 transition-colors bg-transparent"
-              placeholder="admin@example.com"
-            />
-          </div>
-          
-          <div>
-            <label className="block text-xs font-bold tracking-widest text-gray-500 uppercase mb-2">Password</label>
-            <input 
-              name="password"
-              type="password" 
-              required
-              className="w-full border-b-2 border-gray-200 py-3 min-h-[48px] text-sm focus:outline-none focus:border-gold focus:ring-0 transition-colors bg-transparent"
-              placeholder="••••••••"
+              autoComplete="email"
+              className="w-full rounded-[10px] px-4 py-3 text-base text-white placeholder-[#71717b] focus:outline-none focus-visible:ring-2 focus-visible:ring-[#dfbd69]/25"
+              placeholder="IDを入力してください"
+              style={{
+                background: '#27272a',
+                border: '0.556px solid #3f3f47',
+              }}
             />
           </div>
 
+          {/* Password */}
+          <div>
+            <label
+              htmlFor="admin-password"
+              className="block text-sm mb-2"
+              style={{ color: '#9f9fa9' }}
+            >
+              ログインパスワード
+            </label>
+            <div className="relative">
+              <input
+                id="admin-password"
+                name="password"
+                type={showPassword ? 'text' : 'password'}
+                required
+                autoComplete="current-password"
+                className="w-full rounded-[10px] px-4 py-3 pr-12 text-base text-white placeholder-[#71717b] focus:outline-none focus-visible:ring-2 focus-visible:ring-[#dfbd69]/25"
+                placeholder="パスワードを入力してください"
+                style={{
+                  background: '#27272a',
+                  border: '0.556px solid #3f3f47',
+                }}
+              />
+              <button
+                type="button"
+                onClick={() => setShowPassword((v) => !v)}
+                className="absolute right-3.5 top-1/2 -translate-y-1/2 text-white/40 hover:text-white/70 transition-colors"
+                aria-label={showPassword ? 'パスワードを隠す' : 'パスワードを表示'}
+              >
+                <EyeIcon open={showPassword} />
+              </button>
+            </div>
+          </div>
+
+          {/* Error */}
           {state?.error && (
-            <p className="text-red-500 text-xs text-center">{state.error}</p>
+            <p className="text-red-400 text-xs text-center bg-red-500/10 rounded-lg py-2.5 px-4">
+              {state.error}
+            </p>
           )}
 
-          <Button 
-            type="submit" 
-            className="w-full pt-4 pb-4 font-bold tracking-widest text-sm"
+          {/* Submit Button */}
+          <button
+            type="submit"
+            id="admin-login-submit"
             disabled={isPending}
+            className="w-full h-[48px] rounded-[10px] text-base font-semibold transition-opacity disabled:opacity-60 mt-2"
+            style={{
+              background:
+                'linear-gradient(90deg, rgb(223,189,105) 0%, rgb(146,111,52) 100%)',
+              color: '#18181b',
+            }}
           >
-            {isPending ? '認証中...' : 'LOGIN'}
-          </Button>
+            {isPending ? '認証中...' : 'ログイン'}
+          </button>
         </form>
+
+        {/* Footer Links */}
+        <div className="mt-7 text-center space-y-3">
+          <Link
+            href="/admin/forgot-password"
+            className="block text-sm transition-colors"
+            style={{ color: '#9f9fa9' }}
+          >
+            パスワードを忘れた方はこちら
+          </Link>
+          <p className="text-sm tracking-wide" style={{ color: '#9f9fa9' }}>
+            アカウントをお持ちでない方は{' '}
+            <Link
+              href="/admin/register"
+              className="font-medium transition-colors hover:underline"
+              style={{ color: '#dfbd69' }}
+            >
+              新規登録
+            </Link>
+          </p>
+          <Link
+            href="/admin/m/login"
+            className="block text-sm hover:underline"
+            style={{ color: '#9f9fa9' }}
+          >
+            モバイル版はこちら
+          </Link>
+        </div>
+        </div>
       </div>
     </div>
   );

--- a/app/admin/m/forgot-password/page.tsx
+++ b/app/admin/m/forgot-password/page.tsx
@@ -1,0 +1,131 @@
+'use client'
+
+import React, { useActionState } from 'react'
+import Link from 'next/link'
+import { adminForgotPasswordAction } from '@/lib/actions/admin-auth'
+
+function MailIcon() {
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M4 4h16v16H4z" />
+      <path d="m22 6-10 7L2 6" />
+    </svg>
+  )
+}
+
+export default function AdminForgotPasswordMobilePage() {
+  const [state, formAction, isPending] = useActionState(adminForgotPasswordAction, null)
+
+  return (
+    <div className="min-h-screen bg-black flex items-center justify-center px-4 py-10">
+      <div
+        className="w-full max-w-[420px] rounded-[16px] p-1"
+        style={{
+          background:
+            'linear-gradient(128deg, rgb(223,189,105) 0%, rgb(146,111,52) 100%)',
+          boxShadow: '0 0 48px rgba(223,189,105,0.25)',
+        }}
+      >
+        <div
+          className="w-full rounded-[14px] px-8 py-10"
+          style={{
+            background:
+              'linear-gradient(128deg, rgb(24,24,27) 0%, rgb(39,39,42) 50%, rgb(24,24,27) 100%)',
+            boxShadow: '0px 25px 50px 0px rgba(0,0,0,0.25)',
+          }}
+        >
+          <div className="text-center mb-6">
+            <p
+              className="text-white text-sm tracking-[0.3em] uppercase font-light mb-1"
+              style={{ fontFamily: 'var(--font-serif, serif)' }}
+            >
+              CLUB ANIMO
+            </p>
+            <h1 className="text-white text-2xl font-bold tracking-[0.2em] uppercase mb-4">
+              ANIMO CMS
+            </h1>
+            <p
+              className="text-lg font-bold"
+              style={{
+                background:
+                  'linear-gradient(90deg, rgb(223,189,105) 0%, rgb(146,111,52) 100%)',
+                WebkitBackgroundClip: 'text',
+                backgroundClip: 'text',
+                color: 'transparent',
+              }}
+            >
+              パスワードをリセット
+            </p>
+          </div>
+
+          <p className="text-sm text-center mb-8" style={{ color: '#9f9fa9' }}>
+            登録されたメールアドレスを入力してください。<br />
+            パスワードリセット用のリンクをお送りします。
+          </p>
+
+          <form action={formAction} className="space-y-4">
+            <div>
+              <label className="block text-sm mb-2" style={{ color: '#9f9fa9' }}>
+                メールアドレス
+              </label>
+              <div className="relative">
+                <span className="absolute left-3 top-1/2 -translate-y-1/2" style={{ color: '#71717b' }} aria-hidden>
+                  <MailIcon />
+                </span>
+                <input
+                  name="email"
+                  type="email"
+                  required
+                  autoComplete="email"
+                  className="w-full rounded-[10px] pl-11 pr-4 py-3 text-base text-white placeholder-[#71717b] focus:outline-none focus-visible:ring-2 focus-visible:ring-[#dfbd69]/25"
+                  placeholder="example@email.com"
+                  style={{ background: '#27272a', border: '0.617px solid #3f3f47' }}
+                />
+              </div>
+            </div>
+
+            {(state?.error || state?.message) && (
+              <p
+                className="text-xs text-center rounded-lg py-2.5 px-4"
+                style={{
+                  color: state?.error ? '#f87171' : '#9f9fa9',
+                  background: state?.error ? 'rgba(239,68,68,0.1)' : 'rgba(63,63,71,0.35)',
+                }}
+              >
+                {state?.error ?? state?.message}
+              </p>
+            )}
+
+            <button
+              type="submit"
+              disabled={isPending}
+              className="w-full h-[48px] rounded-[10px] text-base font-semibold transition-opacity disabled:opacity-60"
+              style={{
+                background:
+                  'linear-gradient(90deg, rgb(223,189,105) 0%, rgb(146,111,52) 100%)',
+                color: '#18181b',
+              }}
+            >
+              {isPending ? '送信中...' : 'リセットリンクを送信'}
+            </button>
+
+            <Link
+              href="/admin/m/login"
+              className="block w-full h-[49px] rounded-[10px] border text-center leading-[49px] text-base"
+              style={{ borderColor: '#3f3f47', color: '#d4d4d8' }}
+            >
+              ← ログイン画面に戻る
+            </Link>
+          </form>
+
+          <div className="mt-4 text-center">
+            <Link href="/admin/forgot-password" className="text-sm hover:underline" style={{ color: '#9f9fa9' }}>
+              PC版はこちら
+            </Link>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+

--- a/app/admin/m/login/page.tsx
+++ b/app/admin/m/login/page.tsx
@@ -1,0 +1,148 @@
+'use client'
+
+import React, { useActionState, useState } from 'react'
+import Link from 'next/link'
+import { login } from '@/lib/actions/auth'
+
+function EyeIcon({ open }: { open: boolean }) {
+  return open ? (
+    <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" />
+      <circle cx="12" cy="12" r="3" />
+    </svg>
+  ) : (
+    <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94" />
+      <path d="M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19" />
+      <line x1="1" y1="1" x2="23" y2="23" />
+    </svg>
+  )
+}
+
+export default function AdminLoginMobilePage() {
+  const [state, formAction, isPending] = useActionState(login, null)
+  const [showPassword, setShowPassword] = useState(false)
+
+  return (
+    <div className="min-h-screen bg-black flex items-center justify-center px-4 py-10">
+      <div
+        className="w-full max-w-[420px] rounded-[16px] p-1"
+        style={{
+          background:
+            'linear-gradient(126deg, rgb(223,189,105) 0%, rgb(146,111,52) 100%)',
+          boxShadow: '0 0 48px rgba(223,189,105,0.25)',
+        }}
+      >
+        <div
+          className="w-full rounded-[14px] px-8 py-10"
+          style={{
+            background:
+              'linear-gradient(126deg, rgb(24,24,27) 0%, rgb(39,39,42) 50%, rgb(24,24,27) 100%)',
+            boxShadow: '0px 25px 50px 0px rgba(0,0,0,0.25)',
+          }}
+        >
+          <div className="text-center mb-8">
+            <p
+              className="text-white text-sm tracking-[0.3em] uppercase font-light mb-1"
+              style={{ fontFamily: 'var(--font-serif, serif)' }}
+            >
+              CLUB ANIMO
+            </p>
+            <h1 className="text-white text-2xl font-bold tracking-[0.2em] uppercase mb-5">
+              ANIMO CMS
+            </h1>
+            <p
+              className="text-lg font-bold"
+              style={{
+                background:
+                  'linear-gradient(90deg, rgb(223,189,105) 0%, rgb(146,111,52) 100%)',
+                WebkitBackgroundClip: 'text',
+                backgroundClip: 'text',
+                color: 'transparent',
+              }}
+            >
+              Welcome to Animo Dashboard
+            </p>
+          </div>
+
+          <form action={formAction} className="space-y-5">
+            <div>
+              <label className="block text-sm mb-2" style={{ color: '#9f9fa9' }}>
+                ログインID
+              </label>
+              <input
+                name="email"
+                type="email"
+                required
+                autoComplete="email"
+                className="w-full rounded-[10px] px-4 py-3 text-base text-white placeholder-[#71717b] focus:outline-none focus-visible:ring-2 focus-visible:ring-[#dfbd69]/25"
+                placeholder="IDを入力してください"
+                style={{ background: '#27272a', border: '0.617px solid #3f3f47' }}
+              />
+            </div>
+
+            <div>
+              <label className="block text-sm mb-2" style={{ color: '#9f9fa9' }}>
+                ログインパスワード
+              </label>
+              <div className="relative">
+                <input
+                  name="password"
+                  type={showPassword ? 'text' : 'password'}
+                  required
+                  autoComplete="current-password"
+                  className="w-full rounded-[10px] px-4 py-3 pr-12 text-base text-white placeholder-[#71717b] focus:outline-none focus-visible:ring-2 focus-visible:ring-[#dfbd69]/25"
+                  placeholder="パスワードを入力してください"
+                  style={{ background: '#27272a', border: '0.617px solid #3f3f47' }}
+                />
+                <button
+                  type="button"
+                  onClick={() => setShowPassword((v) => !v)}
+                  className="absolute right-3.5 top-1/2 -translate-y-1/2 text-white/40 hover:text-white/70 transition-colors"
+                  aria-label={showPassword ? 'パスワードを隠す' : 'パスワードを表示'}
+                >
+                  <EyeIcon open={showPassword} />
+                </button>
+              </div>
+            </div>
+
+            {state?.error && (
+              <p className="text-red-400 text-xs text-center bg-red-500/10 rounded-lg py-2.5 px-4">
+                {state.error}
+              </p>
+            )}
+
+            <button
+              type="submit"
+              disabled={isPending}
+              className="w-full h-[48px] rounded-[10px] text-base font-semibold transition-opacity disabled:opacity-60"
+              style={{
+                background:
+                  'linear-gradient(90deg, rgb(223,189,105) 0%, rgb(146,111,52) 100%)',
+                color: '#18181b',
+              }}
+            >
+              {isPending ? '認証中...' : 'ログイン'}
+            </button>
+          </form>
+
+          <div className="mt-7 text-center space-y-3">
+            <Link href="/admin/m/forgot-password" className="block text-sm hover:underline" style={{ color: '#9f9fa9' }}>
+              パスワードを忘れた方はこちら
+            </Link>
+            <p className="text-sm" style={{ color: '#9f9fa9' }}>
+              アカウントをお持ちでない方は{' '}
+              <Link href="/admin/m/register" className="font-medium hover:underline" style={{ color: '#dfbd69' }}>
+                新規登録
+              </Link>
+            </p>
+            <Link href="/admin/login" className="block text-sm hover:underline" style={{ color: '#9f9fa9' }}>
+              PC版はこちら
+            </Link>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+

--- a/app/admin/m/register/page.tsx
+++ b/app/admin/m/register/page.tsx
@@ -1,0 +1,251 @@
+'use client'
+
+import React, { useActionState, useState } from 'react'
+import Link from 'next/link'
+import { adminRegisterAction } from '@/lib/actions/admin-auth'
+
+function EyeIcon({ open }: { open: boolean }) {
+  return open ? (
+    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" />
+      <circle cx="12" cy="12" r="3" />
+    </svg>
+  ) : (
+    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94" />
+      <path d="M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19" />
+      <line x1="1" y1="1" x2="23" y2="23" />
+    </svg>
+  )
+}
+
+function MailIcon() {
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M4 4h16v16H4z" />
+      <path d="m22 6-10 7L2 6" />
+    </svg>
+  )
+}
+
+export default function AdminRegisterMobilePage() {
+  const [state, formAction, isPending] = useActionState(adminRegisterAction, null)
+  const [showPassword, setShowPassword] = useState(false)
+  const [showConfirmPassword, setShowConfirmPassword] = useState(false)
+
+  return (
+    <div className="min-h-screen bg-black flex items-center justify-center px-4 py-10">
+      <div
+        className="w-full max-w-[420px] rounded-[16px] p-1"
+        style={{
+          background:
+            'linear-gradient(124deg, rgb(223,189,105) 0%, rgb(146,111,52) 100%)',
+          boxShadow: '0 0 48px rgba(223,189,105,0.25)',
+        }}
+      >
+        <div
+          className="w-full rounded-[14px] px-6 py-6"
+          style={{
+            background:
+              'linear-gradient(124deg, rgb(24,24,27) 0%, rgb(39,39,42) 50%, rgb(24,24,27) 100%)',
+            boxShadow: '0px 25px 50px 0px rgba(0,0,0,0.25)',
+          }}
+        >
+          <div className="text-center mb-4">
+            <p
+              className="text-white text-xs tracking-[0.3em] uppercase font-light mb-1"
+              style={{ fontFamily: 'var(--font-serif, serif)' }}
+            >
+              CLUB ANIMO
+            </p>
+            <h1 className="text-white text-xl font-bold tracking-[0.2em] uppercase mb-3">
+              ANIMO CMS
+            </h1>
+            <p
+              className="text-sm font-bold"
+              style={{
+                background:
+                  'linear-gradient(90deg, rgb(223,189,105) 0%, rgb(146,111,52) 100%)',
+                WebkitBackgroundClip: 'text',
+                backgroundClip: 'text',
+                color: 'transparent',
+              }}
+            >
+              Sign Up
+            </p>
+          </div>
+
+          <form action={formAction} className="space-y-3">
+            <div className="grid grid-cols-2 gap-2">
+              <div>
+                <label className="block text-xs mb-1.5" style={{ color: '#9f9fa9' }}>
+                  苗字
+                </label>
+                <input
+                  name="lastName"
+                  required
+                  className="w-full rounded-[10px] px-2.5 py-2 text-sm text-white placeholder-[#71717b] focus:outline-none focus-visible:ring-2 focus-visible:ring-[#dfbd69]/25"
+                  placeholder="山田"
+                  style={{ background: '#27272a', border: '0.617px solid #3f3f47' }}
+                />
+              </div>
+              <div>
+                <label className="block text-xs mb-1.5" style={{ color: '#9f9fa9' }}>
+                  名前
+                </label>
+                <input
+                  name="firstName"
+                  required
+                  className="w-full rounded-[10px] px-2.5 py-2 text-sm text-white placeholder-[#71717b] focus:outline-none focus-visible:ring-2 focus-visible:ring-[#dfbd69]/25"
+                  placeholder="太郎"
+                  style={{ background: '#27272a', border: '0.617px solid #3f3f47' }}
+                />
+              </div>
+            </div>
+
+            <div>
+              <label className="block text-xs mb-1.5" style={{ color: '#9f9fa9' }}>
+                源氏名
+              </label>
+              <input
+                name="stageName"
+                required
+                className="w-full rounded-[10px] px-2.5 py-2 text-sm text-white placeholder-[#71717b] focus:outline-none focus-visible:ring-2 focus-visible:ring-[#dfbd69]/25"
+                placeholder="源氏名を入力してください"
+                style={{ background: '#27272a', border: '0.617px solid #3f3f47' }}
+              />
+            </div>
+
+            <div>
+              <label className="block text-xs mb-1.5" style={{ color: '#9f9fa9' }}>
+                携帯番号
+              </label>
+              <input
+                name="phone"
+                inputMode="tel"
+                required
+                className="w-full rounded-[10px] px-2.5 py-2 text-sm text-white placeholder-[#71717b] focus:outline-none focus-visible:ring-2 focus-visible:ring-[#dfbd69]/25"
+                placeholder="090-1234-5678"
+                style={{ background: '#27272a', border: '0.617px solid #3f3f47' }}
+              />
+            </div>
+
+            <div>
+              <label className="block text-xs mb-1.5" style={{ color: '#9f9fa9' }}>
+                メールアドレス
+              </label>
+              <div className="relative">
+                <span
+                  className="absolute left-2.5 top-1/2 -translate-y-1/2"
+                  style={{ color: '#71717b' }}
+                  aria-hidden
+                >
+                  <MailIcon />
+                </span>
+                <input
+                  name="email"
+                  type="email"
+                  autoComplete="email"
+                  required
+                  className="w-full rounded-[10px] pl-9 pr-2.5 py-2 text-sm text-white placeholder-[#71717b] focus:outline-none focus-visible:ring-2 focus-visible:ring-[#dfbd69]/25"
+                  placeholder="example@email.com"
+                  style={{ background: '#27272a', border: '0.617px solid #3f3f47' }}
+                />
+              </div>
+            </div>
+
+            <div>
+              <label className="block text-xs mb-1.5" style={{ color: '#9f9fa9' }}>
+                パスワード
+              </label>
+              <div className="relative">
+                <input
+                  name="password"
+                  type={showPassword ? 'text' : 'password'}
+                  autoComplete="new-password"
+                  required
+                  className="w-full rounded-[10px] px-2.5 py-2 pr-9 text-sm text-white placeholder-[#71717b] focus:outline-none focus-visible:ring-2 focus-visible:ring-[#dfbd69]/25"
+                  placeholder="パスワードを入力"
+                  style={{ background: '#27272a', border: '0.617px solid #3f3f47' }}
+                />
+                <button
+                  type="button"
+                  onClick={() => setShowPassword((v) => !v)}
+                  className="absolute right-2.5 top-1/2 -translate-y-1/2 text-white/40 hover:text-white/70 transition-colors"
+                  aria-label={showPassword ? 'パスワードを隠す' : 'パスワードを表示'}
+                >
+                  <EyeIcon open={showPassword} />
+                </button>
+              </div>
+            </div>
+
+            <div>
+              <label className="block text-xs mb-1.5" style={{ color: '#9f9fa9' }}>
+                パスワード確認
+              </label>
+              <div className="relative">
+                <input
+                  name="confirmPassword"
+                  type={showConfirmPassword ? 'text' : 'password'}
+                  autoComplete="new-password"
+                  required
+                  className="w-full rounded-[10px] px-2.5 py-2 pr-9 text-sm text-white placeholder-[#71717b] focus:outline-none focus-visible:ring-2 focus-visible:ring-[#dfbd69]/25"
+                  placeholder="パスワードを再入力"
+                  style={{ background: '#27272a', border: '0.617px solid #3f3f47' }}
+                />
+                <button
+                  type="button"
+                  onClick={() => setShowConfirmPassword((v) => !v)}
+                  className="absolute right-2.5 top-1/2 -translate-y-1/2 text-white/40 hover:text-white/70 transition-colors"
+                  aria-label={showConfirmPassword ? 'パスワードを隠す' : 'パスワードを表示'}
+                >
+                  <EyeIcon open={showConfirmPassword} />
+                </button>
+              </div>
+            </div>
+
+            {(state?.error || state?.message) && (
+              <p
+                className="text-xs text-center rounded-lg py-2 px-3"
+                style={{
+                  color: state?.error ? '#f87171' : '#9f9fa9',
+                  background: state?.error ? 'rgba(239,68,68,0.1)' : 'rgba(63,63,71,0.35)',
+                }}
+              >
+                {state?.error ?? state?.message}
+              </p>
+            )}
+
+            <button
+              type="submit"
+              disabled={isPending}
+              className="w-full h-[36px] rounded-[10px] text-sm font-semibold transition-opacity disabled:opacity-60"
+              style={{
+                background:
+                  'linear-gradient(90deg, rgb(223,189,105) 0%, rgb(146,111,52) 100%)',
+                color: '#18181b',
+              }}
+            >
+              {isPending ? '送信中...' : '新規登録'}
+            </button>
+
+            <Link
+              href="/admin/m/login"
+              className="block w-full h-[37px] rounded-[10px] border text-center leading-[37px] text-sm"
+              style={{ borderColor: '#3f3f47', color: '#d4d4d8' }}
+            >
+              Login
+            </Link>
+          </form>
+
+          <div className="mt-3 text-center">
+            <Link href="/admin/register" className="text-sm hover:underline" style={{ color: '#9f9fa9' }}>
+              PC版はこちら
+            </Link>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+

--- a/app/admin/m/reset-password/page.tsx
+++ b/app/admin/m/reset-password/page.tsx
@@ -1,0 +1,214 @@
+'use client'
+
+import React, { Suspense, useEffect, useMemo, useState } from 'react'
+import Link from 'next/link'
+import { useRouter, useSearchParams } from 'next/navigation'
+import { createBrowserClient } from '@supabase/ssr'
+
+function ResetPasswordForm() {
+  const searchParams = useSearchParams()
+  const router = useRouter()
+  const [isReady, setIsReady] = useState(false)
+  const [isLoading, setIsLoading] = useState(false)
+  const [password, setPassword] = useState('')
+  const [confirmPassword, setConfirmPassword] = useState('')
+  const [error, setError] = useState<string | null>(null)
+  const [message, setMessage] = useState<string | null>(null)
+
+  const supabase = useMemo(
+    () =>
+      createBrowserClient(
+        process.env.NEXT_PUBLIC_SUPABASE_URL!,
+        process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+      ),
+    []
+  )
+
+  useEffect(() => {
+    const checkSession = async () => {
+      const { data } = await supabase.auth.getSession()
+      if (data.session) {
+        setIsReady(true)
+        return
+      }
+
+      const code = searchParams.get('code') || ''
+      if (!code) {
+        setError('リセットリンクが無効または期限切れです。再度お試しください。')
+        return
+      }
+
+      const { error: exchangeError } = await supabase.auth.exchangeCodeForSession(code)
+      if (exchangeError) {
+        setError('リセットリンクが無効または期限切れです。再度お試しください。')
+        return
+      }
+
+      setIsReady(true)
+    }
+
+    checkSession()
+  }, [searchParams, supabase])
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setError(null)
+    setMessage(null)
+
+    if (password !== confirmPassword) {
+      setError('パスワードが一致しません。')
+      return
+    }
+    if (password.length < 8) {
+      setError('パスワードは8文字以上にしてください。')
+      return
+    }
+
+    setIsLoading(true)
+    const { error: updateError } = await supabase.auth.updateUser({ password })
+    setIsLoading(false)
+
+    if (updateError) {
+      setError('パスワードの更新に失敗しました。もう一度お試しください。')
+      return
+    }
+
+    setMessage('パスワードを更新しました。新しいパスワードでログインしてください。')
+    setTimeout(() => router.push('/admin/m/login'), 1500)
+  }
+
+  return (
+    <div className="min-h-screen bg-black flex items-center justify-center px-4 py-10">
+      <div
+        className="w-full max-w-[420px] rounded-[16px] p-1"
+        style={{
+          background:
+            'linear-gradient(131deg, rgb(223,189,105) 0%, rgb(146,111,52) 100%)',
+          boxShadow: '0 0 48px rgba(223,189,105,0.25)',
+        }}
+      >
+        <div
+          className="w-full rounded-[14px] px-8 py-10"
+          style={{
+            background:
+              'linear-gradient(131deg, rgb(24,24,27) 0%, rgb(39,39,42) 50%, rgb(24,24,27) 100%)',
+            boxShadow: '0px 25px 50px 0px rgba(0,0,0,0.25)',
+          }}
+        >
+          <div className="text-center mb-6">
+            <p
+              className="text-white text-sm tracking-[0.3em] uppercase font-light mb-1"
+              style={{ fontFamily: 'var(--font-serif, serif)' }}
+            >
+              CLUB ANIMO
+            </p>
+            <h1 className="text-white text-2xl font-bold tracking-[0.2em] uppercase mb-4">
+              ANIMO CMS
+            </h1>
+            <p
+              className="text-lg font-bold"
+              style={{
+                background:
+                  'linear-gradient(90deg, rgb(223,189,105) 0%, rgb(146,111,52) 100%)',
+                WebkitBackgroundClip: 'text',
+                backgroundClip: 'text',
+                color: 'transparent',
+              }}
+            >
+              パスワードを更新
+            </p>
+          </div>
+
+          {error && (
+            <p className="text-xs text-center rounded-lg py-2.5 px-4 mb-4" style={{ color: '#f87171', background: 'rgba(239,68,68,0.1)' }}>
+              {error}
+            </p>
+          )}
+
+          {message && (
+            <p className="text-xs text-center rounded-lg py-2.5 px-4 mb-4" style={{ color: '#9f9fa9', background: 'rgba(63,63,71,0.35)' }}>
+              {message}
+            </p>
+          )}
+
+          {!isReady ? (
+            <div className="py-10 text-center" style={{ color: '#9f9fa9' }}>
+              確認中...
+            </div>
+          ) : (
+            <form onSubmit={handleSubmit} className="space-y-4">
+              <div>
+                <label className="block text-sm mb-2" style={{ color: '#9f9fa9' }}>
+                  新しいパスワード
+                </label>
+                <input
+                  type="password"
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                  required
+                  minLength={8}
+                  autoComplete="new-password"
+                  className="w-full rounded-[10px] px-4 py-3 text-base text-white placeholder-[#71717b] focus:outline-none focus-visible:ring-2 focus-visible:ring-[#dfbd69]/25"
+                  placeholder="8文字以上"
+                  style={{ background: '#27272a', border: '0.617px solid #3f3f47' }}
+                />
+              </div>
+              <div>
+                <label className="block text-sm mb-2" style={{ color: '#9f9fa9' }}>
+                  パスワード（確認）
+                </label>
+                <input
+                  type="password"
+                  value={confirmPassword}
+                  onChange={(e) => setConfirmPassword(e.target.value)}
+                  required
+                  minLength={8}
+                  autoComplete="new-password"
+                  className="w-full rounded-[10px] px-4 py-3 text-base text-white placeholder-[#71717b] focus:outline-none focus-visible:ring-2 focus-visible:ring-[#dfbd69]/25"
+                  placeholder="再入力"
+                  style={{ background: '#27272a', border: '0.617px solid #3f3f47' }}
+                />
+              </div>
+              <button
+                type="submit"
+                disabled={isLoading}
+                className="w-full h-[48px] rounded-[10px] text-base font-semibold transition-opacity disabled:opacity-60"
+                style={{
+                  background:
+                    'linear-gradient(90deg, rgb(223,189,105) 0%, rgb(146,111,52) 100%)',
+                  color: '#18181b',
+                }}
+              >
+                {isLoading ? '更新中...' : 'パスワードを更新する'}
+              </button>
+            </form>
+          )}
+
+          <div className="mt-6 text-center space-y-2">
+            <Link href="/admin/m/login" className="block text-sm hover:underline" style={{ color: '#9f9fa9' }}>
+              ← ログインへ戻る
+            </Link>
+            <Link href="/admin/reset-password" className="block text-sm hover:underline" style={{ color: '#9f9fa9' }}>
+              PC版はこちら
+            </Link>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default function AdminResetPasswordMobilePage() {
+  return (
+    <Suspense
+      fallback={
+        <div className="min-h-screen bg-black flex items-center justify-center" style={{ color: '#9f9fa9' }}>
+          読み込み中...
+        </div>
+      }
+    >
+      <ResetPasswordForm />
+    </Suspense>
+  )
+}
+

--- a/app/admin/register/page.tsx
+++ b/app/admin/register/page.tsx
@@ -1,0 +1,253 @@
+'use client'
+
+import React, { useActionState, useState } from 'react'
+import Link from 'next/link'
+import { adminRegisterAction } from '@/lib/actions/admin-auth'
+
+function EyeIcon({ open }: { open: boolean }) {
+  return open ? (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="18"
+      height="18"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.8"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" />
+      <circle cx="12" cy="12" r="3" />
+    </svg>
+  ) : (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="18"
+      height="18"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.8"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94" />
+      <path d="M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19" />
+      <line x1="1" y1="1" x2="23" y2="23" />
+    </svg>
+  )
+}
+
+export default function AdminRegisterPage() {
+  const [state, formAction, isPending] = useActionState(adminRegisterAction, null)
+  const [showPassword, setShowPassword] = useState(false)
+  const [showConfirmPassword, setShowConfirmPassword] = useState(false)
+
+  return (
+    <div className="min-h-screen bg-black flex items-center justify-center p-6">
+      <div
+        className="w-full max-w-[448px] rounded-[16px] p-1"
+        style={{
+          background:
+            'linear-gradient(117deg, rgb(223,189,105) 0%, rgb(146,111,52) 100%)',
+          boxShadow: '0 0 48px rgba(223,189,105,0.25)',
+        }}
+      >
+        <div
+          className="w-full rounded-[14px] p-8"
+          style={{
+            background:
+              'linear-gradient(117deg, rgb(24,24,27) 0%, rgb(39,39,42) 50%, rgb(24,24,27) 100%)',
+            boxShadow: '0px 25px 50px 0px rgba(0,0,0,0.25)',
+          }}
+        >
+          <div className="text-center mb-6">
+            <p
+              className="text-white text-sm tracking-[0.3em] uppercase font-light mb-1"
+              style={{ fontFamily: 'var(--font-serif, serif)' }}
+            >
+              CLUB ANIMO
+            </p>
+            <h1 className="text-white text-2xl font-bold tracking-[0.2em] uppercase mb-4">
+              ANIMO CMS
+            </h1>
+            <p
+              className="text-xl font-bold"
+              style={{
+                background:
+                  'linear-gradient(90deg, rgb(223,189,105) 0%, rgb(146,111,52) 100%)',
+                WebkitBackgroundClip: 'text',
+                backgroundClip: 'text',
+                color: 'transparent',
+              }}
+            >
+              Sign Up
+            </p>
+          </div>
+
+          <form action={formAction} className="space-y-4">
+            <div className="grid grid-cols-2 gap-4">
+              <div>
+                <label className="block text-sm mb-2" style={{ color: '#9f9fa9' }}>
+                  苗字
+                </label>
+                <input
+                  name="lastName"
+                  required
+                  className="w-full rounded-[10px] px-4 py-3 text-base text-white placeholder-[#71717b] focus:outline-none focus-visible:ring-2 focus-visible:ring-[#dfbd69]/25"
+                  placeholder="山田"
+                  style={{ background: '#27272a', border: '0.556px solid #3f3f47' }}
+                />
+              </div>
+              <div>
+                <label className="block text-sm mb-2" style={{ color: '#9f9fa9' }}>
+                  名前
+                </label>
+                <input
+                  name="firstName"
+                  required
+                  className="w-full rounded-[10px] px-4 py-3 text-base text-white placeholder-[#71717b] focus:outline-none focus-visible:ring-2 focus-visible:ring-[#dfbd69]/25"
+                  placeholder="太郎"
+                  style={{ background: '#27272a', border: '0.556px solid #3f3f47' }}
+                />
+              </div>
+            </div>
+
+            <div>
+              <label className="block text-sm mb-2" style={{ color: '#9f9fa9' }}>
+                源氏名
+              </label>
+              <input
+                name="stageName"
+                required
+                className="w-full rounded-[10px] px-4 py-3 text-base text-white placeholder-[#71717b] focus:outline-none focus-visible:ring-2 focus-visible:ring-[#dfbd69]/25"
+                placeholder="源氏名を入力してください"
+                style={{ background: '#27272a', border: '0.556px solid #3f3f47' }}
+              />
+            </div>
+
+            <div>
+              <label className="block text-sm mb-2" style={{ color: '#9f9fa9' }}>
+                携帯番号
+              </label>
+              <input
+                name="phone"
+                inputMode="tel"
+                required
+                className="w-full rounded-[10px] px-4 py-3 text-base text-white placeholder-[#71717b] focus:outline-none focus-visible:ring-2 focus-visible:ring-[#dfbd69]/25"
+                placeholder="090-1234-5678"
+                style={{ background: '#27272a', border: '0.556px solid #3f3f47' }}
+              />
+            </div>
+
+            <div>
+              <label className="block text-sm mb-2" style={{ color: '#9f9fa9' }}>
+                メールアドレス
+              </label>
+              <input
+                name="email"
+                type="email"
+                autoComplete="email"
+                required
+                className="w-full rounded-[10px] px-4 py-3 text-base text-white placeholder-[#71717b] focus:outline-none focus-visible:ring-2 focus-visible:ring-[#dfbd69]/25"
+                placeholder="example@email.com"
+                style={{ background: '#27272a', border: '0.556px solid #3f3f47' }}
+              />
+            </div>
+
+            <div>
+              <label className="block text-sm mb-2" style={{ color: '#9f9fa9' }}>
+                パスワード
+              </label>
+              <div className="relative">
+                <input
+                  name="password"
+                  type={showPassword ? 'text' : 'password'}
+                  autoComplete="new-password"
+                  required
+                  className="w-full rounded-[10px] px-4 py-3 pr-12 text-base text-white placeholder-[#71717b] focus:outline-none focus-visible:ring-2 focus-visible:ring-[#dfbd69]/25"
+                  placeholder="パスワードを入力"
+                  style={{ background: '#27272a', border: '0.556px solid #3f3f47' }}
+                />
+                <button
+                  type="button"
+                  onClick={() => setShowPassword((v) => !v)}
+                  className="absolute right-3.5 top-1/2 -translate-y-1/2 text-white/40 hover:text-white/70 transition-colors"
+                  aria-label={showPassword ? 'パスワードを隠す' : 'パスワードを表示'}
+                >
+                  <EyeIcon open={showPassword} />
+                </button>
+              </div>
+            </div>
+
+            <div>
+              <label className="block text-sm mb-2" style={{ color: '#9f9fa9' }}>
+                パスワード確認
+              </label>
+              <div className="relative">
+                <input
+                  name="confirmPassword"
+                  type={showConfirmPassword ? 'text' : 'password'}
+                  autoComplete="new-password"
+                  required
+                  className="w-full rounded-[10px] px-4 py-3 pr-12 text-base text-white placeholder-[#71717b] focus:outline-none focus-visible:ring-2 focus-visible:ring-[#dfbd69]/25"
+                  placeholder="パスワードを再入力"
+                  style={{ background: '#27272a', border: '0.556px solid #3f3f47' }}
+                />
+                <button
+                  type="button"
+                  onClick={() => setShowConfirmPassword((v) => !v)}
+                  className="absolute right-3.5 top-1/2 -translate-y-1/2 text-white/40 hover:text-white/70 transition-colors"
+                  aria-label={showConfirmPassword ? 'パスワードを隠す' : 'パスワードを表示'}
+                >
+                  <EyeIcon open={showConfirmPassword} />
+                </button>
+              </div>
+            </div>
+
+            {(state?.error || state?.message) && (
+              <p
+                className="text-xs text-center rounded-lg py-2.5 px-4"
+                style={{
+                  color: state?.error ? '#f87171' : '#9f9fa9',
+                  background: state?.error ? 'rgba(239,68,68,0.1)' : 'rgba(63,63,71,0.35)',
+                }}
+              >
+                {state?.error ?? state?.message}
+              </p>
+            )}
+
+            <button
+              type="submit"
+              disabled={isPending}
+              className="w-full h-[48px] rounded-[10px] text-base font-semibold transition-opacity disabled:opacity-60"
+              style={{
+                background:
+                  'linear-gradient(90deg, rgb(223,189,105) 0%, rgb(146,111,52) 100%)',
+                color: '#18181b',
+              }}
+            >
+              {isPending ? '送信中...' : '新規登録'}
+            </button>
+
+            <Link
+              href="/admin/login"
+              className="block w-full h-[49px] rounded-[10px] border text-center leading-[49px] text-base"
+              style={{ borderColor: '#3f3f47', color: '#d4d4d8' }}
+            >
+              Login
+            </Link>
+          </form>
+
+          <div className="mt-4 text-center space-y-2">
+            <Link href="/admin/m/register" className="text-sm hover:underline" style={{ color: '#9f9fa9' }}>
+              モバイル版はこちら
+            </Link>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+

--- a/app/admin/reset-password/page.tsx
+++ b/app/admin/reset-password/page.tsx
@@ -1,0 +1,215 @@
+'use client'
+
+import React, { Suspense, useEffect, useMemo, useState } from 'react'
+import Link from 'next/link'
+import { useRouter, useSearchParams } from 'next/navigation'
+import { createBrowserClient } from '@supabase/ssr'
+
+function ResetPasswordForm() {
+  const searchParams = useSearchParams()
+  const router = useRouter()
+  const [isReady, setIsReady] = useState(false)
+  const [isLoading, setIsLoading] = useState(false)
+  const [password, setPassword] = useState('')
+  const [confirmPassword, setConfirmPassword] = useState('')
+  const [error, setError] = useState<string | null>(null)
+  const [message, setMessage] = useState<string | null>(null)
+
+  const supabase = useMemo(
+    () =>
+      createBrowserClient(
+        process.env.NEXT_PUBLIC_SUPABASE_URL!,
+        process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+      ),
+    []
+  )
+
+  useEffect(() => {
+    const checkSession = async () => {
+      const { data } = await supabase.auth.getSession()
+      if (data.session) {
+        setIsReady(true)
+        return
+      }
+
+      const code = searchParams.get('code') || ''
+      if (!code) {
+        setError('リセットリンクが無効または期限切れです。再度お試しください。')
+        return
+      }
+
+      const { error: exchangeError } = await supabase.auth.exchangeCodeForSession(code)
+      if (exchangeError) {
+        setError('リセットリンクが無効または期限切れです。再度お試しください。')
+        return
+      }
+
+      setIsReady(true)
+    }
+
+    checkSession()
+  }, [searchParams, supabase])
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setError(null)
+    setMessage(null)
+
+    if (password !== confirmPassword) {
+      setError('パスワードが一致しません。')
+      return
+    }
+    if (password.length < 8) {
+      setError('パスワードは8文字以上にしてください。')
+      return
+    }
+
+    setIsLoading(true)
+    const { error: updateError } = await supabase.auth.updateUser({ password })
+    setIsLoading(false)
+
+    if (updateError) {
+      setError('パスワードの更新に失敗しました。もう一度お試しください。')
+      return
+    }
+
+    setMessage('パスワードを更新しました。新しいパスワードでログインしてください。')
+    setTimeout(() => router.push('/admin/login'), 1500)
+  }
+
+  return (
+    <div className="min-h-screen bg-black flex items-center justify-center p-6">
+      <div
+        className="w-full max-w-[448px] rounded-[16px] p-1"
+        style={{
+          background:
+            'linear-gradient(131deg, rgb(223,189,105) 0%, rgb(146,111,52) 100%)',
+          boxShadow: '0 0 48px rgba(223,189,105,0.25)',
+        }}
+      >
+        <div
+          className="w-full rounded-[14px] p-10"
+          style={{
+            background:
+              'linear-gradient(131deg, rgb(24,24,27) 0%, rgb(39,39,42) 50%, rgb(24,24,27) 100%)',
+            boxShadow: '0px 25px 50px 0px rgba(0,0,0,0.25)',
+          }}
+        >
+          <div className="text-center mb-6">
+            <p
+              className="text-white text-sm tracking-[0.3em] uppercase font-light mb-1"
+              style={{ fontFamily: 'var(--font-serif, serif)' }}
+            >
+              CLUB ANIMO
+            </p>
+            <h1 className="text-white text-2xl font-bold tracking-[0.2em] uppercase mb-4">
+              ANIMO CMS
+            </h1>
+            <p
+              className="text-lg font-bold"
+              style={{
+                background:
+                  'linear-gradient(90deg, rgb(223,189,105) 0%, rgb(146,111,52) 100%)',
+                WebkitBackgroundClip: 'text',
+                backgroundClip: 'text',
+                color: 'transparent',
+              }}
+            >
+              パスワードを更新
+            </p>
+          </div>
+
+          {error && (
+            <p className="text-xs text-center rounded-lg py-2.5 px-4 mb-4" style={{ color: '#f87171', background: 'rgba(239,68,68,0.1)' }}>
+              {error}
+            </p>
+          )}
+
+          {message && (
+            <p className="text-xs text-center rounded-lg py-2.5 px-4 mb-4" style={{ color: '#9f9fa9', background: 'rgba(63,63,71,0.35)' }}>
+              {message}
+            </p>
+          )}
+
+          {!isReady ? (
+            <div className="py-10 text-center" style={{ color: '#9f9fa9' }}>
+              確認中...
+            </div>
+          ) : (
+            <form onSubmit={handleSubmit} className="space-y-4">
+              <div>
+                <label className="block text-sm mb-2" style={{ color: '#9f9fa9' }}>
+                  新しいパスワード
+                </label>
+                <input
+                  type="password"
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                  required
+                  minLength={8}
+                  autoComplete="new-password"
+                  className="w-full rounded-[10px] px-4 py-3 text-base text-white placeholder-[#71717b] focus:outline-none focus-visible:ring-2 focus-visible:ring-[#dfbd69]/25"
+                  placeholder="8文字以上"
+                  style={{ background: '#27272a', border: '0.556px solid #3f3f47' }}
+                />
+              </div>
+              <div>
+                <label className="block text-sm mb-2" style={{ color: '#9f9fa9' }}>
+                  パスワード（確認）
+                </label>
+                <input
+                  type="password"
+                  value={confirmPassword}
+                  onChange={(e) => setConfirmPassword(e.target.value)}
+                  required
+                  minLength={8}
+                  autoComplete="new-password"
+                  className="w-full rounded-[10px] px-4 py-3 text-base text-white placeholder-[#71717b] focus:outline-none focus-visible:ring-2 focus-visible:ring-[#dfbd69]/25"
+                  placeholder="再入力"
+                  style={{ background: '#27272a', border: '0.556px solid #3f3f47' }}
+                />
+              </div>
+
+              <button
+                type="submit"
+                disabled={isLoading}
+                className="w-full h-[48px] rounded-[10px] text-base font-semibold transition-opacity disabled:opacity-60"
+                style={{
+                  background:
+                    'linear-gradient(90deg, rgb(223,189,105) 0%, rgb(146,111,52) 100%)',
+                  color: '#18181b',
+                }}
+              >
+                {isLoading ? '更新中...' : 'パスワードを更新する'}
+              </button>
+            </form>
+          )}
+
+          <div className="mt-6 text-center space-y-2">
+            <Link href="/admin/login" className="block text-sm hover:underline" style={{ color: '#9f9fa9' }}>
+              ← ログインへ戻る
+            </Link>
+            <Link href="/admin/m/reset-password" className="block text-sm hover:underline" style={{ color: '#9f9fa9' }}>
+              モバイル版はこちら
+            </Link>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default function AdminResetPasswordPage() {
+  return (
+    <Suspense
+      fallback={
+        <div className="min-h-screen bg-black flex items-center justify-center" style={{ color: '#9f9fa9' }}>
+          読み込み中...
+        </div>
+      }
+    >
+      <ResetPasswordForm />
+    </Suspense>
+  )
+}
+

--- a/lib/actions/admin-auth.ts
+++ b/lib/actions/admin-auth.ts
@@ -1,0 +1,161 @@
+'use server'
+
+import { createClient } from '@/lib/supabase/server'
+import { createServiceClient } from '@/lib/supabase/service'
+
+const PRODUCTION_AUTH_BASE_URL = 'https://club-animo.jp'
+
+function resolveAuthBaseUrl() {
+  const candidates = [
+    process.env.NEXT_PUBLIC_APP_URL,
+    process.env.NEXT_PUBLIC_SITE_URL,
+    process.env.APP_URL,
+  ]
+
+  for (const candidate of candidates) {
+    if (!candidate) continue
+
+    try {
+      const url = new URL(candidate)
+      const isLocal =
+        url.hostname === 'localhost' ||
+        url.hostname === '127.0.0.1' ||
+        url.hostname.endsWith('.local')
+
+      if (isLocal) continue
+      return url.origin
+    } catch {
+      // ignore invalid env value and continue
+    }
+  }
+
+  return PRODUCTION_AUTH_BASE_URL
+}
+
+export async function adminRegister(formData: FormData) {
+  const lastName = (formData.get('lastName') as string | null)?.trim() ?? ''
+  const firstName = (formData.get('firstName') as string | null)?.trim() ?? ''
+  const stageName = (formData.get('stageName') as string | null)?.trim() ?? ''
+  const phone = (formData.get('phone') as string | null)?.trim() ?? ''
+  const email = (formData.get('email') as string | null)?.trim().toLowerCase() ?? ''
+  const password = (formData.get('password') as string | null) ?? ''
+  const confirmPassword = (formData.get('confirmPassword') as string | null) ?? ''
+
+  if (!lastName || !firstName || !stageName || !phone || !email || !password) {
+    return { success: false as const, error: 'すべての項目を入力してください。' }
+  }
+  if (password !== confirmPassword) {
+    return { success: false as const, error: 'パスワードが一致しません。' }
+  }
+  if (password.length < 8) {
+    return { success: false as const, error: 'パスワードは8文字以上にしてください。' }
+  }
+
+  const supabase = await createClient()
+  const serviceRoleClient = createServiceClient()
+  const authBaseUrl = resolveAuthBaseUrl()
+
+  const { data, error } = await supabase.auth.signUp({
+    email,
+    password,
+    options: {
+      emailRedirectTo: `${authBaseUrl}/admin/login`,
+    },
+  })
+
+  if (error) {
+    return {
+      success: false as const,
+      error: `アカウント作成に失敗しました: ${error.message}`,
+    }
+  }
+
+  if (!data.user) {
+    return {
+      success: false as const,
+      error: 'アカウント作成の応答が不正でした。時間をおいて再度お試しください。',
+    }
+  }
+
+  const displayName = stageName || `${lastName} ${firstName}`.trim()
+  const { error: profileError } = await serviceRoleClient
+    .from('profiles')
+    .upsert({
+      id: data.user.id,
+      display_name: displayName,
+      last_name: lastName,
+      first_name: firstName,
+      stage_name: stageName,
+      phone,
+      updated_at: new Date().toISOString(),
+    })
+
+  if (profileError) {
+    return {
+      success: false as const,
+      error: `プロフィール保存に失敗しました: ${profileError.message}`,
+    }
+  }
+
+  return {
+    success: true as const,
+    message:
+      'アカウントを登録しました。確認メールが届く場合は認証後にログインしてください。',
+  }
+}
+
+export async function adminRegisterAction(state: unknown, formData: FormData) {
+  return adminRegister(formData)
+}
+
+export async function adminForgotPassword(formData: FormData) {
+  const email = (formData.get('email') as string | null)?.trim().toLowerCase() ?? ''
+
+  if (!email) {
+    return { success: false as const, error: 'メールアドレスを入力してください。' }
+  }
+
+  const supabase = await createClient()
+  const authBaseUrl = resolveAuthBaseUrl()
+
+  const { error } = await supabase.auth.resetPasswordForEmail(email, {
+    redirectTo: `${authBaseUrl}/admin/reset-password`,
+  })
+
+  if (error) {
+    const normalized = error.message.toLowerCase()
+
+    if (normalized.includes('redirect url') && normalized.includes('not allowed')) {
+      return {
+        success: false as const,
+        error: '再設定リンクURLが許可されていません。認証設定（URL Configuration）をご確認ください。',
+      }
+    }
+
+    if (
+      normalized.includes('error sending recovery email') ||
+      normalized.includes('failed to send message') ||
+      normalized.includes('smtp')
+    ) {
+      return {
+        success: false as const,
+        error: '再設定メールの送信に失敗しました。SMTP設定をご確認ください。',
+      }
+    }
+
+    if (normalized.includes('rate limit')) {
+      return {
+        success: false as const,
+        error: '短時間での送信回数が上限に達しました。しばらく待ってから再度お試しください。',
+      }
+    }
+
+    return { success: false as const, error: error.message }
+  }
+
+  return { success: true as const, message: 'パスワード再設定のメールを送信しました。' }
+}
+
+export async function adminForgotPasswordAction(state: unknown, formData: FormData) {
+  return adminForgotPassword(formData)
+}

--- a/lib/supabase/middleware.ts
+++ b/lib/supabase/middleware.ts
@@ -2,6 +2,16 @@ import { createServerClient } from '@supabase/ssr'
 import { NextResponse, type NextRequest } from 'next/server'
 
 const ALLOWED_ADMIN_ROLES = new Set(['owner', 'manager', 'admin', 'staff'])
+const ADMIN_PUBLIC_PATHS = new Set([
+  '/admin/login',
+  '/admin/register',
+  '/admin/forgot-password',
+  '/admin/reset-password',
+  '/admin/m/login',
+  '/admin/m/register',
+  '/admin/m/forgot-password',
+  '/admin/m/reset-password',
+])
 
 async function getAppRole(
   supabase: ReturnType<typeof createServerClient>,
@@ -73,7 +83,7 @@ export async function updateSession(request: NextRequest) {
   const pathname = request.nextUrl.pathname
 
   // Protect /admin routes
-  if (pathname.startsWith('/admin') && !pathname.startsWith('/admin/login')) {
+  if (pathname.startsWith('/admin') && !ADMIN_PUBLIC_PATHS.has(pathname)) {
     if (!user) {
       const url = request.nextUrl.clone()
       url.pathname = '/admin/login'
@@ -94,8 +104,8 @@ export async function updateSession(request: NextRequest) {
     }
   }
 
-  // Redirect logged in users away from login page
-  if (pathname.startsWith('/admin/login') && user) {
+  // Redirect logged in users away from auth pages
+  if (ADMIN_PUBLIC_PATHS.has(pathname) && user) {
     const role = await getAppRole(supabase, user.id)
 
     if (!role || !ALLOWED_ADMIN_ROLES.has(role)) {

--- a/middleware.ts
+++ b/middleware.ts
@@ -2,6 +2,35 @@ import { updateSession } from '@/lib/supabase/middleware'
 import { NextResponse, type NextRequest } from 'next/server'
 import { checkRateLimit } from '@/lib/rate-limit'
 
+const ADMIN_DESKTOP_AUTH_PATHS = new Set([
+  '/admin/login',
+  '/admin/register',
+  '/admin/forgot-password',
+  '/admin/reset-password',
+])
+
+function isAdminDesktopAuthPath(pathname: string) {
+  return ADMIN_DESKTOP_AUTH_PATHS.has(pathname)
+}
+
+function isAdminMobileAuthPath(pathname: string) {
+  return (
+    pathname.startsWith('/admin/m/') &&
+    ADMIN_DESKTOP_AUTH_PATHS.has(pathname.replace('/admin/m', '/admin'))
+  )
+}
+
+function preferMobileView(request: NextRequest) {
+  const forcedView = request.nextUrl.searchParams.get('view')
+  if (forcedView === 'desktop') return false
+  if (forcedView === 'mobile') return true
+
+  const userAgent = request.headers.get('user-agent') ?? ''
+  // 誤判定を避けるため、タブレットはデスクトップ扱いに寄せる
+  if (/iPad/i.test(userAgent)) return false
+  return /Android|iPhone|iPod|Mobi/i.test(userAgent)
+}
+
 export async function middleware(request: NextRequest) {
   const host = request.headers.get('host')
   if (host === 'www.club-animo.jp') {
@@ -9,6 +38,23 @@ export async function middleware(request: NextRequest) {
     redirectUrl.host = 'club-animo.jp'
     redirectUrl.protocol = 'https'
     return NextResponse.redirect(redirectUrl, 308)
+  }
+
+  // === Admin Auth (Desktop/Mobile) routing ===
+  // 端末判定で /admin/* と /admin/m/* を行き来させる（view=desktop|mobile で固定可能）
+  const pathname = request.nextUrl.pathname
+  const shouldMobile = preferMobileView(request)
+
+  if (isAdminDesktopAuthPath(pathname) && shouldMobile) {
+    const url = request.nextUrl.clone()
+    url.pathname = `/admin/m${pathname.replace('/admin', '')}`
+    return NextResponse.redirect(url)
+  }
+
+  if (isAdminMobileAuthPath(pathname) && !shouldMobile) {
+    const url = request.nextUrl.clone()
+    url.pathname = pathname.replace('/admin/m', '/admin')
+    return NextResponse.redirect(url)
   }
 
   // === Rate Limit (Simple in-memory) ===

--- a/supabase/migrations/20260411090000_add_admin_profile_fields.sql
+++ b/supabase/migrations/20260411090000_add_admin_profile_fields.sql
@@ -1,0 +1,10 @@
+-- ==========================================
+-- Admin Auth: profiles 追加項目
+-- ==========================================
+
+ALTER TABLE public.profiles
+  ADD COLUMN IF NOT EXISTS first_name text,
+  ADD COLUMN IF NOT EXISTS last_name text,
+  ADD COLUMN IF NOT EXISTS stage_name text,
+  ADD COLUMN IF NOT EXISTS phone text;
+


### PR DESCRIPTION
Add admin login/register/forgot/reset pages for desktop and mobile routes.

- Whitelist auth routes in Supabase session middleware
- Add UA-based redirect with view override
- Add admin signup + password reset actions and extend profiles