### PR TITLE
feat(line): add LINE webhook endpoint

### DIFF
--- a/app/api/line/route.ts
+++ b/app/api/line/route.ts
@@ -1,8 +1,6 @@
 import { NextResponse } from 'next/server';
-import * as crypto from 'crypto';
 
 const LINE_CHANNEL_ACCESS_TOKEN = process.env.LINE_CHANNEL_ACCESS_TOKEN;
-const LINE_CHANNEL_SECRET = process.env.LINE_CHANNEL_SECRET;
 const LINE_GROUP_ID = process.env.LINE_GROUP_ID;
 
 // ─── LINE Push Message 送信ユーティリティ ───────────────────────────────────
@@ -38,58 +36,6 @@ export async function sendLineGroupMessage(message: string) {
     return { ok: false };
   }
   return sendLineMessage(LINE_GROUP_ID, message);
-}
-
-// ─── Webhook 署名検証 ────────────────────────────────────────────────────────
-function verifySignature(body: string, signature: string): boolean {
-  if (!LINE_CHANNEL_SECRET) return true; // SECRET 未設定時は検証スキップ（開発用）
-  const hash = crypto
-    .createHmac('SHA256', LINE_CHANNEL_SECRET)
-    .update(body)
-    .digest('base64');
-  return hash === signature;
-}
-
-// ─── Webhook 受信 (LINE → サーバー) ─────────────────────────────────────────
-// グループに Bot を招待してメッセージを送ると、
-// Vercel Functions ログに groupId が出力されます。
-export async function POST(req: Request) {
-  try {
-    const rawBody = await req.text();
-    const signature = req.headers.get('x-line-signature') ?? '';
-
-    // 署名検証
-    if (!verifySignature(rawBody, signature)) {
-      console.error('[LINE] 署名検証失敗');
-      return NextResponse.json({ error: 'Invalid signature' }, { status: 401 });
-    }
-
-    const body = JSON.parse(rawBody);
-    const events = body.events ?? [];
-
-    for (const event of events) {
-      const source = event.source ?? {};
-
-      // ── グループ ID / ルーム ID をログ出力（LINE_GROUP_ID 取得用） ──
-      if (source.groupId) {
-        console.log('[LINE] ✅ groupId:', source.groupId);
-      }
-      if (source.roomId) {
-        console.log('[LINE] ✅ roomId:', source.roomId);
-      }
-      if (source.userId) {
-        console.log('[LINE] userId:', source.userId, '| type:', source.type);
-      }
-
-      // イベント種別をログ出力
-      console.log('[LINE] event.type:', event.type, '| source.type:', source.type);
-    }
-
-    return NextResponse.json({ success: true });
-  } catch (err) {
-    console.error('[LINE] Webhook 処理エラー:', err);
-    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
-  }
 }
 
 // ─── 管理画面「LINE テスト送信」用エンドポイント ─────────────────────────────

--- a/app/api/line/webhook/route.ts
+++ b/app/api/line/webhook/route.ts
@@ -1,0 +1,57 @@
+import { NextResponse } from 'next/server';
+import * as crypto from 'crypto';
+
+function verifyLineSignature(rawBody: Buffer, signature: string, channelSecret: string) {
+  if (!signature) return false;
+  const hash = crypto
+    .createHmac('SHA256', channelSecret)
+    .update(rawBody)
+    .digest('base64');
+
+  // timingSafeEqual requires buffers with the same length
+  const a = Buffer.from(hash);
+  const b = Buffer.from(signature);
+  if (a.length !== b.length) return false;
+  return crypto.timingSafeEqual(a, b);
+}
+
+export async function POST(req: Request) {
+  const channelSecret = process.env.LINE_CHANNEL_SECRET;
+
+  if (!channelSecret) {
+    console.error('[LINE] LINE_CHANNEL_SECRET が未設定です。');
+    return NextResponse.json({ error: 'LINE_CHANNEL_SECRET is not set' }, { status: 500 });
+  }
+
+  try {
+    const rawBodyBuffer = Buffer.from(await req.arrayBuffer());
+    const signature = req.headers.get('x-line-signature') ?? '';
+
+    if (!verifyLineSignature(rawBodyBuffer, signature, channelSecret)) {
+      console.error('[LINE] 署名検証失敗');
+      return NextResponse.json({ error: 'Invalid signature' }, { status: 401 });
+    }
+
+    const body = JSON.parse(rawBodyBuffer.toString('utf-8'));
+    const events = body?.events ?? [];
+
+    console.log('[LINE] webhook received:', {
+      destination: body?.destination,
+      eventsCount: Array.isArray(events) ? events.length : 0,
+    });
+
+    for (const event of events) {
+      console.log('[LINE] event:', {
+        type: event?.type,
+        mode: event?.mode,
+        timestamp: event?.timestamp,
+        source: event?.source,
+      });
+    }
+
+    return NextResponse.json({ ok: true }, { status: 200 });
+  } catch (err) {
+    console.error('[LINE] Webhook 処理エラー:', err);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}


### PR DESCRIPTION
## Summary
LINE Messaging API の webhook 受信エンドポイントを `/api/line/webhook` に分離して実装しました。

## Changes
- `POST /api/line/webhook` を追加（`x-line-signature` を `LINE_CHANNEL_SECRET` で検証）
- 受信イベントの概要とイベント種別/送信元をログ出力
- 既存 `app/api/line` から webhook POST を削除し、GET（テスト送信）に責務を限定

## Impact
- LINE Developers 側の Webhook URL を `/api/line/webhook` に更新が必要

## Test Plan
- `npm run build`
- LINE Developers の Webhook 検証で 200 が返ること

## Notes
- 環境変数: `LINE_CHANNEL_SECRET` が必須
