### PR TITLE
feat(auth): sync heading styles with Figma designs for all auth screens

### DIFF
--- a/app/admin/forgot-password/page.tsx
+++ b/app/admin/forgot-password/page.tsx
@@ -55,7 +55,7 @@ export default function AdminForgotPasswordPage() {
               ANIMO CMS
             </h1>
             <p
-              className="text-lg font-bold"
+              className="text-2xl font-bold"
               style={{
                 background:
                   'linear-gradient(90deg, rgb(223,189,105) 0%, rgb(146,111,52) 100%)',

--- a/app/admin/login/page.tsx
+++ b/app/admin/login/page.tsx
@@ -57,8 +57,13 @@ export default function LoginPage() {
             ANIMO CMS
           </h1>
           <p
-            className="text-sm font-semibold tracking-wide"
-            style={{ color: '#C9A84C' }}
+            className="text-2xl font-bold"
+            style={{
+              background: 'linear-gradient(90deg, rgb(223,189,105) 0%, rgb(146,111,52) 100%)',
+              WebkitBackgroundClip: 'text',
+              backgroundClip: 'text',
+              color: 'transparent',
+            }}
           >
             Welcome to Animo Dashboard
           </p>

--- a/app/admin/m/forgot-password/page.tsx
+++ b/app/admin/m/forgot-password/page.tsx
@@ -45,7 +45,7 @@ export default function AdminForgotPasswordMobilePage() {
               ANIMO CMS
             </h1>
             <p
-              className="text-lg font-bold"
+              className="text-2xl font-bold"
               style={{
                 background:
                   'linear-gradient(90deg, rgb(223,189,105) 0%, rgb(146,111,52) 100%)',

--- a/app/admin/m/login/page.tsx
+++ b/app/admin/m/login/page.tsx
@@ -52,7 +52,7 @@ export default function AdminLoginMobilePage() {
               ANIMO CMS
             </h1>
             <p
-              className="text-lg font-bold"
+              className="text-2xl font-bold"
               style={{
                 background:
                   'linear-gradient(90deg, rgb(223,189,105) 0%, rgb(146,111,52) 100%)',

--- a/app/admin/m/register/page.tsx
+++ b/app/admin/m/register/page.tsx
@@ -62,7 +62,7 @@ export default function AdminRegisterMobilePage() {
               ANIMO CMS
             </h1>
             <p
-              className="text-sm font-bold"
+              className="text-lg font-bold"
               style={{
                 background:
                   'linear-gradient(90deg, rgb(223,189,105) 0%, rgb(146,111,52) 100%)',

--- a/app/admin/register/page.tsx
+++ b/app/admin/register/page.tsx
@@ -73,7 +73,7 @@ export default function AdminRegisterPage() {
               ANIMO CMS
             </h1>
             <p
-              className="text-xl font-bold"
+              className="text-lg font-bold"
               style={{
                 background:
                   'linear-gradient(90deg, rgb(223,189,105) 0%, rgb(146,111,52) 100%)',


### PR DESCRIPTION
Update heading text sizes and gradient styles across 6 auth pages to match Figma:
- Login Desktop/Mobile: text-2xl bold gold gradient (was text-sm/#C9A84C)
- Register Desktop/Mobile: text-lg bold (18px per Figma)
- Forgot Password Desktop/Mobile: text-2xl bold (24px per Figma)