### PR TITLE
feat(cast/schedule): add weekly shift view with premium gold week sel…

### DIFF
--- a/app/(cast)/cast/dashboard/page.tsx
+++ b/app/(cast)/cast/dashboard/page.tsx
@@ -5,8 +5,8 @@ import { formatDistanceToNowStrict } from 'date-fns';
 import { ja } from 'date-fns/locale';
 import { getCurrentCast } from '@/lib/actions/cast-auth';
 import { getMyShiftSubmission } from '@/lib/actions/cast-shifts';
-import { getTargetWeekMonday } from '@/lib/shift-utils';
-import { getMyConfirmedSchedules } from '@/lib/actions/cast-change-requests';
+import { getTargetWeekMonday, formatDate } from '@/lib/shift-utils';
+import { getMySchedulesForWeek } from '@/lib/actions/cast-change-requests';
 import { getCastTodayCheckin, getCastTodayReservations } from '@/lib/actions/today';
 import { getCastNotices } from '@/lib/actions/cast-notices';
 import { createClient } from '@/lib/supabase/server';
@@ -18,10 +18,9 @@ import {
 } from '@/components/features/cast/CastMobileShell';
 import { getJstDateString } from '@/lib/date-utils';
 
-function getWeeklySummaryLabel(value: 'work' | 'off' | 'unknown') {
-  if (value === 'work') return { text: '●', color: 'text-[#33b36b]' };
-  if (value === 'off') return { text: 'OFF', color: 'text-[#6b7280]' };
-  return { text: '未', color: 'text-[#e6a23c]' };
+function getWeeklySummaryLabel(value: 'work' | 'off') {
+  if (value === 'work') return { text: '○', color: 'text-[#3b82f6]' };
+  return { text: '×', color: 'text-[#ef4444]' };
 }
 
 function getNoticeTone(importance: 'high' | 'normal') {
@@ -43,10 +42,15 @@ export default async function CastDashboardPage() {
   const supabase = await createClient();
   const today = getJstDateString();
 
+  // 翌週月曜（シフト提出ステータス用）
   const nextWeekBaseDate = new Date();
   nextWeekBaseDate.setDate(nextWeekBaseDate.getDate() + 7);
   const nextMondayDate = getTargetWeekMonday(nextWeekBaseDate);
-  const nextMondayStr = new Date(nextMondayDate.getTime() - nextMondayDate.getTimezoneOffset() * 60000).toISOString().split('T')[0];
+  const nextMondayStr = formatDate(nextMondayDate);
+
+  // 今週月曜（スケジュール表示用）
+  const thisWeekMondayDate = getTargetWeekMonday(new Date());
+  const thisWeekMondayStr = formatDate(thisWeekMondayDate);
 
   const [
     { data: shiftSubmission },
@@ -58,7 +62,7 @@ export default async function CastDashboardPage() {
     { data: recentPosts },
   ] = await Promise.all([
     getMyShiftSubmission(nextMondayStr),
-    getMyConfirmedSchedules(cast.id, 7),
+    getMySchedulesForWeek(cast.id, thisWeekMondayStr),
     getCastNotices(cast.id),
     getCastTodayCheckin(),
     getCastTodayReservations(),
@@ -87,22 +91,25 @@ export default async function CastDashboardPage() {
   ].filter(Boolean) as string[];
 
   const unreadNotices = notices.filter((notice) => !notice.is_read).slice(0, 3);
+  // 今週7日分（月〜日）
   const summaryDates = Array.from({ length: 7 }, (_, index) => {
-    const date = new Date(nextMondayDate);
-    date.setDate(nextMondayDate.getDate() + index);
+    const date = new Date(thisWeekMondayDate);
+    date.setDate(thisWeekMondayDate.getDate() + index);
     return date;
   });
 
+  // work_date -> 'work' のマップ（レコードなし = 休み）
   const scheduleStatusMap = new Map(
     (schedules ?? []).map((schedule) => [
       schedule.work_date,
-      schedule.status === 'confirmed' ? 'work' : 'unknown',
+      'work' as const,
     ])
   );
 
-  const submittedCount = summaryDates.filter((date) =>
-    Boolean(scheduleStatusMap.get(date.toISOString().split('T')[0]))
+  const workCount = summaryDates.filter((date) =>
+    scheduleStatusMap.has(formatDate(date))
   ).length;
+  const offCount = 7 - workCount;
 
   return (
     <CastMobileShell>
@@ -239,28 +246,37 @@ export default async function CastDashboardPage() {
               <CalendarDays className="h-4 w-4 text-[#c9a76a]" />
               今週のスケジュール
             </div>
-            <Link href="/cast/shift" className="flex items-center gap-1 text-xs text-[#8f96a3]">
+            <Link href="/cast/schedule" className="flex items-center gap-1 text-xs text-[#8f96a3]">
               詳細
               <ChevronRight className="h-3.5 w-3.5" />
             </Link>
           </div>
           <div className="mt-4 grid grid-cols-7 gap-1.5">
             {summaryDates.map((date) => {
-              const dateKey = date.toISOString().split('T')[0];
-              const indicator = getWeeklySummaryLabel((scheduleStatusMap.get(dateKey) as 'work' | 'off' | 'unknown') ?? 'unknown');
+              const dateKey = formatDate(date);
+              const status = scheduleStatusMap.has(dateKey) ? 'work' : 'off';
+              const indicator = getWeeklySummaryLabel(status);
+              const isToday = dateKey === today;
 
               return (
-                <div key={dateKey} className="rounded-[10px] border border-transparent px-1 py-2 text-center">
-                  <div className="text-[10px] text-[#6b7280]">{date.toLocaleDateString('ja-JP', { weekday: 'short' }).replace('曜', '')}</div>
-                  <div className={`mt-2 text-[9px] font-bold ${indicator.color}`}>{indicator.text}</div>
+                <div
+                  key={dateKey}
+                  className={`rounded-[10px] border px-1 py-2 text-center ${
+                    isToday ? 'border-[rgba(201,167,106,0.4)] bg-[rgba(201,167,106,0.08)]' : 'border-transparent'
+                  }`}
+                >
+                  <div className={`text-[10px] ${isToday ? 'text-[#c9a76a]' : 'text-[#6b7280]'}`}>
+                    {date.toLocaleDateString('ja-JP', { weekday: 'short' }).replace('曜', '')}
+                  </div>
+                  <div className={`mt-2 text-base font-bold leading-none ${indicator.color}`}>{indicator.text}</div>
                 </div>
               );
             })}
           </div>
           <div className="mt-4 flex items-center justify-between border-t border-white/8 pt-3 text-xs">
             <div className="flex gap-4">
-              <span className="text-[#a9afbc]">出勤: <strong className="text-[#f7f4ed]">{submittedCount}日</strong></span>
-              <span className="text-[#e6a23c]">未提出 {Math.max(7 - submittedCount, 0)}日</span>
+              <span className="text-[#a9afbc]">出勤: <strong className="text-[#3b82f6]">{workCount}日</strong></span>
+              <span className="text-[#a9afbc]">休み: <strong className="text-[#ef4444]">{offCount}日</strong></span>
             </div>
             <span className="font-bold text-[#c9a76a]">
               {todayShift ? `本日 ${todayShift.start_time?.slice(0, 5)}-${todayShift.end_time?.slice(0, 5)}` : '本日 OFF'}

--- a/app/(cast)/cast/schedule/page.tsx
+++ b/app/(cast)/cast/schedule/page.tsx
@@ -1,0 +1,122 @@
+import Link from 'next/link';
+import { redirect } from 'next/navigation';
+import { ChevronLeft, CalendarDays } from 'lucide-react';
+import { getCurrentCast } from '@/lib/actions/cast-auth';
+import { getMySchedulesForWeek, getMyPastSchedules } from '@/lib/actions/cast-change-requests';
+import { getTargetWeekMonday, formatDate } from '@/lib/shift-utils';
+import {
+  CastMobileHeader,
+  CastMobileShell,
+} from '@/components/features/cast/CastMobileShell';
+import { WeekScheduleClient } from '@/components/features/cast/WeekScheduleClient';
+
+/** YYYY-MM-DD の月曜から N週前の月曜文字列を生成 */
+function nWeeksAgoMonday(thisMonday: Date, n: number): string {
+  const d = new Date(thisMonday);
+  d.setDate(thisMonday.getDate() - n * 7);
+  return d.toISOString().split('T')[0];
+}
+
+/** 週ラベル (例: 4/14(月) 〜 4/20(日)) */
+function weekLabel(mondayStr: string): string {
+  const monday = new Date(mondayStr);
+  const sunday = new Date(monday);
+  sunday.setDate(monday.getDate() + 6);
+  const fmt = (d: Date) => `${d.getMonth() + 1}/${d.getDate()}`;
+  return `${fmt(monday)}(月) 〜 ${fmt(sunday)}(日)`;
+}
+
+export default async function CastSchedulePage() {
+  const cast = await getCurrentCast();
+  if (!cast) redirect('/cast/login');
+
+  const thisWeekMondayDate = getTargetWeekMonday(new Date());
+  const thisWeekMondayStr = formatDate(thisWeekMondayDate);
+
+  // 4週前の月曜
+  const fourWeeksAgo = new Date(thisWeekMondayDate);
+  fourWeeksAgo.setDate(thisWeekMondayDate.getDate() - 28);
+  const fourWeeksAgoStr = formatDate(fourWeeksAgo);
+
+  // 今週前日（過去シフトの上限）
+  const prevDay = new Date(thisWeekMondayDate);
+  prevDay.setDate(thisWeekMondayDate.getDate() - 1);
+  const prevDayStr = formatDate(prevDay);
+
+  const today = formatDate(new Date());
+
+  // 各週の月曜を生成（今週 + 過去4週）
+  const weekMondays = [
+    thisWeekMondayStr,
+    nWeeksAgoMonday(thisWeekMondayDate, 1),
+    nWeeksAgoMonday(thisWeekMondayDate, 2),
+    nWeeksAgoMonday(thisWeekMondayDate, 3),
+    nWeeksAgoMonday(thisWeekMondayDate, 4),
+  ];
+
+  // 並列でスケジュール取得
+  const [thisWeekResult, pastResult] = await Promise.all([
+    getMySchedulesForWeek(cast.id, thisWeekMondayStr),
+    getMyPastSchedules(cast.id, fourWeeksAgoStr, prevDayStr),
+  ]);
+
+  // 過去スケジュールをwork_dateでマップ
+  const pastMap = new Map((pastResult.data ?? []).map((s) => [s.work_date, s]));
+
+  // 各週のデータをまとめる
+  const weeks = weekMondays.map((mondayStr, i) => {
+    if (i === 0) {
+      // 今週
+      return {
+        mondayStr,
+        label: weekLabel(mondayStr),
+        isCurrentWeek: true,
+        schedules: thisWeekResult.data ?? [],
+      };
+    }
+    // 過去週: mondayStr〜mondayStr+6 のレコードをフィルタ
+    const monday = new Date(mondayStr);
+    const weekSchedules = [];
+    for (let d = 0; d < 7; d++) {
+      const day = new Date(monday);
+      day.setDate(monday.getDate() + d);
+      const dateKey = day.toISOString().split('T')[0];
+      const s = pastMap.get(dateKey);
+      if (s) weekSchedules.push(s);
+    }
+    return {
+      mondayStr,
+      label: weekLabel(mondayStr),
+      isCurrentWeek: false,
+      schedules: weekSchedules,
+    };
+  });
+
+  return (
+    <CastMobileShell>
+      <CastMobileHeader
+        leftSlot={
+          <Link
+            href="/cast/dashboard"
+            className="flex items-center gap-1 text-[#8f96a3] hover:text-[#f7f4ed] transition-colors"
+          >
+            <ChevronLeft className="h-4 w-4" />
+            <span className="text-xs">ダッシュボード</span>
+          </Link>
+        }
+      />
+
+      <main className="mx-auto flex min-h-[calc(100vh-108px)] w-full max-w-[422px] flex-col gap-4 px-4 pb-28 pt-5">
+        {/* ページタイトル */}
+        <div className="flex items-center gap-2">
+          <CalendarDays className="h-4 w-4 text-[#c9a76a]" />
+          <h1 className="text-lg font-bold text-[#f7f4ed]">スケジュール</h1>
+          <span className="ml-auto text-[10px] text-[#6b7280]">直近5週</span>
+        </div>
+
+        {/* クライアントコンポーネント（週選択 + 詳細表示） */}
+        <WeekScheduleClient weeks={weeks} today={today} />
+      </main>
+    </CastMobileShell>
+  );
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -268,3 +268,146 @@ body {
     @apply font-sans;
   }
 }
+
+/* ============================================================
+   .card-premium-skin — 共通プレミアム積層スキン v4
+   ============================================================
+   4層アーキテクチャ:
+   Layer 1 — root自体  = Back Black Foundation (#393939)
+   Layer 2 — ::before  = Gold Material Layer (透過ゴールド)
+   Layer 3 — ::after   = Gold Main Layer (メタリック)
+   Layer 4 — __surface = Front Dark Gloss Surface (漆黒)
+   ============================================================ */
+
+.card-premium-skin {
+  --bright-gold-bezel: 4px;
+  --dark-gold-bezel: 8px;
+}
+
+.card-premium-skin {
+  position: relative;
+  isolation: isolate;
+  transition: translate 220ms cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+/* Layer 1+2: Foundation #393939 + Dark Gold */
+.card-premium-skin::after {
+  content: '';
+  position: absolute;
+  inset: calc(-1 * var(--dark-gold-bezel));
+  border-radius: inherit;
+  z-index: -2;
+  pointer-events: none;
+  background:
+    radial-gradient(50% 50% at 50% 50%, rgba(250,224,77,0.10) 0%, rgba(249,223,81,0.10) 100%),
+    linear-gradient(89deg, rgba(230,179,0,0.50) 1.17%, rgba(245,214,74,0.50) 18.26%, rgba(245,214,74,0.50) 54.88%, rgba(237,184,3,0.50) 90.99%, rgba(230,179,0,0.50) 98.83%),
+    #393939;
+  box-shadow: 2px 3px 15px 0 rgba(0,0,0,1);
+}
+
+/* Layer 3: Bright Gold */
+.card-premium-skin::before {
+  content: '';
+  position: absolute;
+  inset: calc(-1 * var(--bright-gold-bezel));
+  border-radius: inherit;
+  z-index: -1;
+  pointer-events: none;
+  background:
+    radial-gradient(50% 50% at 50% 50%, rgba(250,224,77,0.40) 0%, rgba(249,223,81,0.40) 100%),
+    linear-gradient(89deg, #E6B300 1.17%, #F5D64A 18.26%, #E6B300 56.27%, #F5D64A 77.43%, #EDB803 90.99%);
+  box-shadow: 0 -10px 19px -4px #EBB802 inset;
+}
+
+/* Layer 4: Front Dark Gloss Surface */
+.card-premium-skin__surface {
+  position: relative;
+  z-index: 0;
+  border-radius: inherit;
+  background: linear-gradient(1deg, #000 7.95%, #1C1C1C 27.54%, #000 79.40%, #383838 104.18%, #191717 127.80%);
+}
+
+.card-premium-skin > * {
+  position: relative;
+  z-index: 1;
+}
+
+@media (hover: hover) {
+  .card-premium-skin:hover::before {
+    inset: calc(-1 * var(--bright-gold-bezel) - 1px);
+    transition: inset 180ms cubic-bezier(0.4, 0, 0.2, 1);
+  }
+  .card-premium-skin:hover::after {
+    inset: calc(-1 * var(--dark-gold-bezel) - 1px);
+    transition: inset 180ms cubic-bezier(0.4, 0, 0.2, 1);
+  }
+  .card-premium-skin::before,
+  .card-premium-skin::after {
+    transition: inset 220ms cubic-bezier(0.4, 0, 0.2, 1), box-shadow 220ms cubic-bezier(0.4, 0, 0.2, 1);
+  }
+}
+
+.card-premium-skin:active::before { inset: 0px; transition: inset 80ms cubic-bezier(0.4, 0, 0.2, 1); }
+.card-premium-skin:active::after  { inset: -1px; transition: inset 80ms cubic-bezier(0.4, 0, 0.2, 1); }
+.card-premium-skin:active         { translate: 2px 2px; transition: translate 80ms cubic-bezier(0.4, 0, 0.2, 1); }
+
+/* ============================================================
+   .btn-week-selector — 週選択ボタン用プレミアムスキン
+   非対称: 左=ほぼ金なし / 右=ほんの少し金が見える
+   ============================================================ */
+.btn-week-selector {
+  position: relative;
+  isolation: isolate;
+  border-radius: 14px;
+}
+
+/* Layer 1+2: Foundation + Dark Gold — 右下にのみ露出 */
+.btn-week-selector::after {
+  content: '';
+  position: absolute;
+  inset-block: -6px;
+  inset-inline-start: 1px;   /* 左: ほぼフラッシュ（金ほぼ隠れる） */
+  inset-inline-end: -6px;    /* 右: 6px 露出 */
+  border-radius: inherit;
+  z-index: -2;
+  pointer-events: none;
+  background:
+    radial-gradient(50% 50% at 50% 50%, rgba(250,224,77,0.10) 0%, rgba(249,223,81,0.10) 100%),
+    linear-gradient(89deg, rgba(230,179,0,0.50) 1.17%, rgba(245,214,74,0.50) 18.26%, rgba(245,214,74,0.50) 54.88%, rgba(237,184,3,0.50) 90.99%, rgba(230,179,0,0.50) 98.83%),
+    #393939;
+  box-shadow: 2px 3px 15px 0 rgba(0,0,0,1);
+}
+
+/* Layer 3: Bright Gold — 右に少しだけ見える */
+.btn-week-selector::before {
+  content: '';
+  position: absolute;
+  inset-block: -2px;
+  inset-inline-start: 2px;   /* 左: 表面で隠れる */
+  inset-inline-end: -2px;    /* 右: 2px だけ金が覗く */
+  border-radius: inherit;
+  z-index: -1;
+  pointer-events: none;
+  background:
+    radial-gradient(50% 50% at 50% 50%, rgba(250,224,77,0.40) 0%, rgba(249,223,81,0.40) 100%),
+    linear-gradient(89deg, #E6B300 1.17%, #F5D64A 18.26%, #E6B300 56.27%, #F5D64A 77.43%, #EDB803 90.99%);
+  box-shadow: 0 -6px 14px -3px #EBB802 inset;
+}
+
+/* Layer 4: Dark Gloss Surface — ボタン表面 */
+.btn-week-selector__surface {
+  position: relative;
+  z-index: 0;
+  border-radius: 12px;
+  background: linear-gradient(135deg, #0b0d12 0%, #131720 60%, #1a1f2e 100%);
+}
+
+.btn-week-selector > * {
+  position: relative;
+  z-index: 1;
+}
+
+/* active: 押し込み */
+.btn-week-selector:active { translate: 1px 1px; transition: translate 80ms; }
+.btn-week-selector:active::before { inset-block: 0; inset-inline-end: 0; }
+.btn-week-selector:active::after  { inset-block: 0; inset-inline-end: -1px; }

--- a/components/features/cast/CastMobileShell.tsx
+++ b/components/features/cast/CastMobileShell.tsx
@@ -11,6 +11,7 @@ type CastMobileShellProps = {
 };
 
 type CastMobileHeaderProps = {
+  leftSlot?: ReactNode;
   rightSlot?: ReactNode;
 };
 
@@ -40,10 +41,11 @@ export function CastMobileShell({ children, showBottomNav = true }: CastMobileSh
   );
 }
 
-export function CastMobileHeader({ rightSlot }: CastMobileHeaderProps) {
+export function CastMobileHeader({ leftSlot, rightSlot }: CastMobileHeaderProps) {
   return (
     <header className="sticky top-0 z-30 border-b border-white/7 bg-[#0b0d12]/95 backdrop-blur">
       <div className="relative flex h-12 items-center justify-center px-4">
+        {leftSlot ? <div className="absolute left-4 top-1/2 -translate-y-1/2">{leftSlot}</div> : null}
         <div className="font-serif text-[16px] font-medium tracking-[0.18em] text-[#f7f4ed]">ANIMO</div>
         {rightSlot ? <div className="absolute right-4 top-1/2 -translate-y-1/2">{rightSlot}</div> : null}
       </div>

--- a/components/features/cast/WeekScheduleClient.tsx
+++ b/components/features/cast/WeekScheduleClient.tsx
@@ -1,0 +1,220 @@
+'use client';
+
+import { useState, useRef, useEffect } from 'react';
+import { ChevronDown, ChevronRight } from 'lucide-react';
+import { formatDate } from '@/lib/shift-utils';
+
+type Schedule = {
+  id: string;
+  work_date: string;
+  start_time: string | null;
+  end_time: string | null;
+  status: string;
+};
+
+type WeekData = {
+  mondayStr: string;
+  label: string;
+  isCurrentWeek: boolean;
+  schedules: Schedule[];
+};
+
+const DAY_LABELS = ['月', '火', '水', '木', '金', '土', '日'];
+
+function buildWeekDates(mondayStr: string): Date[] {
+  const monday = new Date(mondayStr);
+  return Array.from({ length: 7 }, (_, i) => {
+    const d = new Date(monday);
+    d.setDate(monday.getDate() + i);
+    return d;
+  });
+}
+
+function weekLabel(mondayStr: string): string {
+  const monday = new Date(mondayStr);
+  const sunday = new Date(monday);
+  sunday.setDate(monday.getDate() + 6);
+  const fmt = (d: Date) => `${d.getMonth() + 1}/${d.getDate()}`;
+  return `${fmt(monday)}(月) 〜 ${fmt(sunday)}(日)`;
+}
+
+function WorkBadge({ schedule }: { schedule: Schedule | null }) {
+  if (!schedule) {
+    return (
+      <span className="inline-flex items-center gap-1">
+        <span className="text-base font-bold text-[#ef4444]">×</span>
+        <span className="text-xs text-[#6b7280]">休み</span>
+      </span>
+    );
+  }
+  return (
+    <span className="inline-flex items-center gap-1">
+      <span className="text-base font-bold text-[#3b82f6]">○</span>
+      <span className="text-xs text-[#8f96a3]">
+        {schedule.start_time?.slice(0, 5) ?? '?'}〜{schedule.end_time?.slice(0, 5) ?? 'LAST'}
+      </span>
+    </span>
+  );
+}
+
+export function WeekScheduleClient({ weeks, today }: { weeks: WeekData[]; today: string }) {
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const [isOpen, setIsOpen] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  const selectedWeek = weeks[selectedIndex];
+
+  // 外クリックでドロップダウンを閉じる
+  useEffect(() => {
+    function handleClickOutside(e: MouseEvent) {
+      if (dropdownRef.current && !dropdownRef.current.contains(e.target as Node)) {
+        setIsOpen(false);
+      }
+    }
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, []);
+
+  const weekDates = buildWeekDates(selectedWeek.mondayStr);
+  const scheduleMap = new Map(selectedWeek.schedules.map((s) => [s.work_date, s]));
+  const workCount = selectedWeek.schedules.length;
+  const offCount = 7 - workCount;
+
+  return (
+    <div className="space-y-4">
+      {/* ─── 週選択ボタン（4レイヤープレミアムスキン） ─── */}
+      <div className="relative" ref={dropdownRef}>
+        <button
+          onClick={() => setIsOpen((v) => !v)}
+          className="btn-week-selector w-full"
+          aria-expanded={isOpen}
+        >
+          <div className="btn-week-selector__surface flex items-center justify-between px-4 py-3">
+            <div className="flex items-center gap-3">
+              {selectedWeek.isCurrentWeek && (
+                <span className="rounded-full bg-[rgba(201,167,106,0.2)] px-2 py-0.5 text-[10px] font-bold text-[#c9a76a]">
+                  今週
+                </span>
+              )}
+              <span className="text-sm font-bold text-[#f7f4ed]">{selectedWeek.label}</span>
+            </div>
+            <div className="flex items-center gap-3">
+              <div className="flex items-center gap-2 text-[11px]">
+                <span className="font-bold text-[#3b82f6]">○{workCount}</span>
+                <span className="text-[#6b7280]">/</span>
+                <span className="font-bold text-[#ef4444]">×{offCount}</span>
+              </div>
+              <ChevronDown
+                className={`h-4 w-4 text-[#8f96a3] transition-transform duration-200 ${isOpen ? 'rotate-180' : ''}`}
+              />
+            </div>
+          </div>
+        </button>
+
+        {/* ドロップダウンリスト */}
+        {isOpen && (
+          <div className="absolute left-0 right-0 top-full z-50 mt-2 overflow-hidden rounded-[16px] border border-white/10 bg-[#131720] shadow-[0_16px_40px_-8px_rgba(0,0,0,0.7)]">
+            {weeks.map((week, i) => (
+              <button
+                key={week.mondayStr}
+                onClick={() => { setSelectedIndex(i); setIsOpen(false); }}
+                className={`flex w-full items-center justify-between px-4 py-3.5 text-left transition-colors ${
+                  i === selectedIndex
+                    ? 'bg-[rgba(201,167,106,0.1)] text-[#c9a76a]'
+                    : 'text-[#a9afbc] hover:bg-white/5'
+                } ${i > 0 ? 'border-t border-white/5' : ''}`}
+              >
+                <div className="flex items-center gap-2">
+                  {week.isCurrentWeek && (
+                    <span className="rounded-full bg-[rgba(201,167,106,0.15)] px-1.5 py-0.5 text-[9px] font-bold text-[#c9a76a]">
+                      今週
+                    </span>
+                  )}
+                  <span className="text-xs font-bold">{week.label}</span>
+                </div>
+                <div className="flex items-center gap-2 text-[10px]">
+                  <span className="font-bold text-[#3b82f6]">○{week.schedules.length}</span>
+                  <span className="text-[#6b7280]">/</span>
+                  <span className="font-bold text-[#ef4444]">×{7 - week.schedules.length}</span>
+                  {i === selectedIndex && <ChevronRight className="ml-1 h-3 w-3 text-[#c9a76a]" />}
+                </div>
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* ─── 選択週のシフト詳細 ─── */}
+      <div className="overflow-hidden rounded-[20px] border border-white/8 bg-[#131720]">
+        {/* 週ヘッダー */}
+        <div className="flex items-center justify-between border-b border-white/8 px-5 py-4">
+          <div>
+            <div className="text-[10px] uppercase tracking-[0.14em] text-[#6b7280]">
+              {selectedWeek.isCurrentWeek ? 'This Week' : 'Past Week'}
+            </div>
+            <div className="text-sm font-bold text-[#f7f4ed]">
+              {selectedWeek.isCurrentWeek ? '今週のシフト' : '過去のシフト'}
+            </div>
+          </div>
+          <div className="text-right">
+            <div className="text-[11px] text-[#6b7280]">{selectedWeek.label}</div>
+            <div className="mt-0.5 flex items-center justify-end gap-2 text-[11px]">
+              <span className="font-bold text-[#3b82f6]">出勤 {workCount}日</span>
+              <span className="text-[#6b7280]">/</span>
+              <span className="font-bold text-[#ef4444]">休み {offCount}日</span>
+            </div>
+          </div>
+        </div>
+
+        {/* 7日分リスト */}
+        <div className="divide-y divide-white/5">
+          {weekDates.map((date, i) => {
+            const dateKey = formatDate(date);
+            const schedule = scheduleMap.get(dateKey) ?? null;
+            const isToday = dateKey === today;
+            const dayLabel = DAY_LABELS[i];
+            const isSat = i === 5;
+            const isSun = i === 6;
+
+            return (
+              <div
+                key={dateKey}
+                className={`flex items-center justify-between px-5 py-3 ${
+                  isToday ? 'bg-[rgba(201,167,106,0.06)]' : ''
+                }`}
+              >
+                {/* 日付 */}
+                <div className="flex items-center gap-3">
+                  <div
+                    className={`flex h-9 w-9 flex-col items-center justify-center rounded-lg border text-center ${
+                      isToday
+                        ? 'border-[rgba(201,167,106,0.5)] bg-[rgba(201,167,106,0.12)]'
+                        : 'border-white/8 bg-white/3'
+                    }`}
+                  >
+                    <span className={`text-[9px] font-bold ${
+                      isToday ? 'text-[#c9a76a]' : isSat ? 'text-[#60a5fa]' : isSun ? 'text-[#f87171]' : 'text-[#6b7280]'
+                    }`}>
+                      {dayLabel}
+                    </span>
+                    <span className={`text-xs font-bold ${isToday ? 'text-[#c9a76a]' : 'text-[#f7f4ed]'}`}>
+                      {date.getMonth() + 1}/{date.getDate()}
+                    </span>
+                  </div>
+                  {isToday && (
+                    <span className="rounded-full bg-[rgba(201,167,106,0.15)] px-2 py-0.5 text-[10px] font-bold text-[#c9a76a]">
+                      本日
+                    </span>
+                  )}
+                </div>
+
+                {/* ステータス */}
+                <WorkBadge schedule={schedule} />
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/lib/actions/cast-change-requests.ts
+++ b/lib/actions/cast-change-requests.ts
@@ -130,3 +130,48 @@ export async function submitShiftChangeRequest(
   revalidatePath('/cast/dashboard');
   return { success: true };
 }
+
+/**
+ * 指定週（月曜日起点 YYYY-MM-DD）の確定スケジュールを取得する
+ * ダッシュボードの今週表示・スケジュール履歴ページで使用
+ */
+export async function getMySchedulesForWeek(castId: string, weekMondayStr: string) {
+  const supabase = await createClient();
+
+  const monday = new Date(weekMondayStr);
+  const sunday = new Date(monday);
+  sunday.setDate(monday.getDate() + 6);
+  const sundayStr = sunday.toISOString().split('T')[0];
+
+  const { data, error } = await supabase
+    .from('cast_schedules')
+    .select('id, work_date, start_time, end_time, status')
+    .eq('cast_id', castId)
+    .gte('work_date', weekMondayStr)
+    .lte('work_date', sundayStr)
+    .order('work_date', { ascending: true });
+
+  if (error) return { data: [] as { id: string; work_date: string; start_time: string | null; end_time: string | null; status: string }[], error: error.message };
+  return { data: data ?? [], error: null };
+}
+
+/**
+ * 過去N週のスケジュールをまとめて取得する（スケジュール履歴ページ用）
+ * @param castId キャストID
+ * @param fromStr 取得開始日 YYYY-MM-DD（過去方向の境界）
+ * @param toStr   取得終了日 YYYY-MM-DD（今週月曜の前日）
+ */
+export async function getMyPastSchedules(castId: string, fromStr: string, toStr: string) {
+  const supabase = await createClient();
+
+  const { data, error } = await supabase
+    .from('cast_schedules')
+    .select('id, work_date, start_time, end_time, status')
+    .eq('cast_id', castId)
+    .gte('work_date', fromStr)
+    .lte('work_date', toStr)
+    .order('work_date', { ascending: false });
+
+  if (error) return { data: [] as { id: string; work_date: string; start_time: string | null; end_time: string | null; status: string }[], error: error.message };
+  return { data: data ?? [], error: null };
+}


### PR DESCRIPTION
…ector

- Fix dashboard 今週スケジュール: was showing next week dates, now shows current week
- Change shift indicators from ●/OFF/未 to ○(blue)/×(red) for clarity
- Route 詳細 button to /cast/schedule (was /cast/shift)
- Add getMySchedulesForWeek / getMyPastSchedules server actions
- Create /cast/schedule page: week selector dropdown + 7-day shift detail
- CastMobileHeader: add leftSlot prop for back navigation
- globals.css: add .card-premium-skin v4 and .btn-week-selector (asymmetric gold bezel)
- WeekScheduleClient: 5-week dropdown (this week + past 4), client-side state