### PR TITLE
[codex] Fix Vercel build failure

### DIFF
--- a/app/(cast)/cast/dashboard/page.tsx
+++ b/app/(cast)/cast/dashboard/page.tsx
@@ -320,15 +320,11 @@ export default async function CastDashboardPage() {
                 <ChevronRight className="h-3.5 w-3.5" />
               </div>
             </div>
-            <Link href="/cast/schedule" className="flex items-center gap-1 text-xs text-[#8f96a3]">
-              詳細
-              <ChevronRight className="h-3.5 w-3.5" />
-            </Link>
-          </div>
-          <div className="mt-4 grid grid-cols-7 gap-1.5">
-            {summaryDates.map((date) => {
-              const dateKey = date.toISOString().split('T')[0];
-              const indicator = getWeeklySummaryLabel((scheduleStatusMap.get(dateKey) as 'work' | 'off' | 'unknown') ?? 'unknown');
+            <div className="mt-4 grid grid-cols-7 gap-1.5">
+              {summaryDates.map((date) => {
+                const dateKey = formatDate(date);
+                const isToday = dateKey === today;
+                const indicator = getWeeklySummaryLabel(scheduleStatusMap.has(dateKey) ? 'work' : 'off');
 
                 return (
                   <div
@@ -348,8 +344,8 @@ export default async function CastDashboardPage() {
             <span className="font-bold text-[#c9a76a]">
               {todayShift ? `本日 ${todayShift.start_time?.slice(0, 5) ?? '未定'}-${todayShift.end_time?.slice(0, 5) ?? '未定'}` : '本日 OFF'}
             </span>
-          </div>
-        </CastMobileCard>
+          </CastMobileCard>
+        </Link>
 
         <CastMobileCard className="overflow-hidden bg-[#181d27]">
           <div className="flex items-center justify-between border-b border-white/8 px-5 py-4">

--- a/components/features/today/ReservationForm.tsx
+++ b/components/features/today/ReservationForm.tsx
@@ -103,8 +103,8 @@ export function ReservationForm({
                   <div className="rounded-[10px] bg-[#131720] px-3 py-2 text-[13px] text-[#f7f4ed]">{r.guest_count ?? 1}名</div>
                 </div>
               </div>
-            )
-          })}
+            </div>
+          ))}
         </div>
       ) : (
         <p className="mb-4 text-[13px] text-[#a9afbc]">来店予定がある方は入力してください</p>
@@ -168,4 +168,3 @@ export function ReservationForm({
     </div>
   )
 }
-

--- a/lib/actions/cast-auth.ts
+++ b/lib/actions/cast-auth.ts
@@ -3,6 +3,7 @@
 import { cookies } from 'next/headers';
 import {
   CAST_REAUTH_COOKIE_NAME,
+  CAST_REAUTH_WINDOW_DAYS,
   CAST_REAUTH_WINDOW_MS,
   normalizeCastPhone,
   toE164JpPhone,

--- a/lib/auth/admin-roles.ts
+++ b/lib/auth/admin-roles.ts
@@ -11,18 +11,20 @@ type RoleRow = {
 }
 
 type RoleLookupClient = {
-  from(table: 'user_roles' | 'profiles'): {
-    select(columns: string): {
-      eq(column: string, value: string): {
-        maybeSingle(): Promise<{ data: RoleRow | null }>
-      }
+  from(table: string): unknown
+}
+
+type RoleLookupQuery = {
+  select(columns: string): {
+    eq(column: string, value: string): {
+      maybeSingle(): PromiseLike<{ data: RoleRow | null }>
     }
   }
 }
 
 export async function getAppRole(client: RoleLookupClient, userId: string) {
-  const { data: userRole } = await client
-    .from('user_roles')
+  const userRolesQuery = client.from('user_roles') as RoleLookupQuery
+  const { data: userRole } = await userRolesQuery
     .select('role')
     .eq('user_id', userId)
     .maybeSingle()
@@ -31,8 +33,8 @@ export async function getAppRole(client: RoleLookupClient, userId: string) {
     return userRole.role
   }
 
-  const { data: profile } = await client
-    .from('profiles')
+  const profilesQuery = client.from('profiles') as RoleLookupQuery
+  const { data: profile } = await profilesQuery
     .select('role')
     .eq('id', userId)
     .maybeSingle()


### PR DESCRIPTION
## Summary
Fixes the Vercel production build failure on `main` caused by malformed TSX and follow-on TypeScript errors.

## Changes
- Repair malformed JSX in the cast dashboard schedule card.
- Close the reservation card JSX correctly in the today reservation form.
- Relax the shared admin role lookup helper type to match Supabase query builders.
- Import the missing cast reauth window constant used by cast auth.

## Impact
- Restores `next build` for the app.
- No DB, auth config, env, routing, SEO, or UI redesign changes.

## Test Plan
- `pnpm lint`
- `pnpm build`

## Notes
- Existing lint warnings remain, but there are no lint errors.