### PR TITLE
fix(admin): redirect legacy /admin/huma-resources to /admin/human-resources

### DIFF
--- a/app/admin/(protected)/huma-resources/page.tsx
+++ b/app/admin/(protected)/huma-resources/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from 'next/navigation';
+
+export default function LegacyHumaResourcesPage() {
+  redirect('/admin/human-resources');
+}


### PR DESCRIPTION
### Motivation
- Legacy or mistyped requests to `/admin/huma-resources` returned 404 because the actual page is at `/admin/human-resources`, so add a compatibility redirect to restore access.

### Description
- Add `app/admin/(protected)/huma-resources/page.tsx` which immediately calls `redirect('/admin/human-resources')` to provide a non-destructive compatibility route.

### Testing
- Ran `pnpm lint` which completes (only existing unrelated warnings remain), and attempted `pnpm build` which failed in this environment due to external Google Fonts fetch errors from `next/font` and is unrelated to this route change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9f60c83dc832191cfc43b1b1f7066)