### PR TITLE
fix(home): remove fallback cast display and schedule CTAs from TODAY'S CAST

### DIFF
--- a/app/(public)/page.tsx
+++ b/app/(public)/page.tsx
@@ -108,9 +108,8 @@ export default async function HomePage() {
     },
   ];
 
-  // Today's Cast: is_todayフラグ優先。なければ最大10名表示
   const todayCasts = dbCasts.filter((c) => c.is_today);
-  const displayTodayCasts = todayCasts.length > 0 ? todayCasts.slice(0, 10) : dbCasts.slice(0, 10);
+  const displayTodayCasts = todayCasts.slice(0, 10);
   
   // 在籍キャスト用 (最大10名表示)
   const displayAllCasts = dbCasts.slice(0, 10);
@@ -183,10 +182,7 @@ export default async function HomePage() {
               <GsapRevealTitle text="Today's Cast" />
             </h2>
             <div className="w-px h-12 bg-linear-to-b from-gold to-transparent mx-auto mb-4 opacity-50" />
-            <p className="text-xs text-gray-400 font-serif luxury-tracking uppercase mb-6">本日の出勤</p>
-            <Link href="/shift" className="inline-flex items-center text-gold text-xs font-bold tracking-widest hover:underline underline-offset-4 uppercase font-serif">
-              View Schedule →
-            </Link>
+            <p className="text-xs text-gray-400 font-serif luxury-tracking uppercase">本日の出勤</p>
           </FadeIn>
 
           <div
@@ -249,11 +245,6 @@ export default async function HomePage() {
             </div>
           )}
 
-          <div className="mt-8 text-center md:hidden">
-            <Button asChild variant="outline" className="w-full">
-              <Link href="/shift">出勤スケジュールを見る</Link>
-            </Button>
-          </div>
         </div>
       </section>
 


### PR DESCRIPTION
## Summary

- **Root cause fixed**: `displayTodayCasts` previously fell back to `dbCasts.slice(0, 10)` when no cast had `is_today=true`, causing all active casts to appear as today's working staff. Now `displayTodayCasts = todayCasts.slice(0, 10)` only — when no one is flagged, the existing "本日の出勤予定はまだ公開されていません。" empty-state renders correctly.
- **VIEW SCHEDULE link removed** from the TODAY'S CAST section header (`app/(public)/page.tsx:187`).
- **出勤スケジュールを見る mobile CTA removed** from the TODAY'S CAST section footer (`app/(public)/page.tsx:252–256`).

## Files changed

- `app/(public)/page.tsx` — 2 insertions, 11 deletions

## Diff summary

```diff
-  // Today's Cast: is_todayフラグ優先。なければ最大10名表示
   const todayCasts = dbCasts.filter((c) => c.is_today);
-  const displayTodayCasts = todayCasts.length > 0 ? todayCasts.slice(0, 10) : dbCasts.slice(0, 10);
+  const displayTodayCasts = todayCasts.slice(0, 10);

-  <p className="... mb-6">本日の出勤</p>
-  <Link href="/shift" ...>View Schedule →</Link>
+  <p className="...">本日の出勤</p>

-  <div className="mt-8 text-center md:hidden">
-    <Button asChild variant="outline" className="w-full">
-      <Link href="/shift">出勤スケジュールを見る</Link>
-    </Button>
-  </div>
```

## Verification

- `pnpm lint`: 0 errors (36 pre-existing warnings, none in `page.tsx`)
- `pnpm build`: TypeScript compiled successfully (`✓ Compiled successfully in 12.0s`); subsequent failure is pre-existing missing Supabase env vars in sandbox, unrelated to this change
- `grep -R "dbCasts.slice(0, 10)" app lib components`: only `displayAllCasts` (在籍キャスト section) remains — TODAY'S CAST fallback is gone
- `grep -R "VIEW SCHEDULE\|View Schedule" app lib components`: no results
- `grep -R "出勤スケジュールを見る" app lib components`: no results

## Test plan

- [ ] Confirm TODAY'S CAST section is empty (shows "本日の出勤予定はまだ公開されていません。") when no cast has `is_today=true`
- [ ] Confirm TODAY'S CAST shows only flagged casts when `is_today=true` is set on cast records
- [ ] Confirm VIEW SCHEDULE link no longer appears in the TODAY'S CAST heading
- [ ] Confirm 出勤スケジュールを見る button no longer appears on mobile
- [ ] Confirm NEWS, hero, footer, bottom nav, and all other sections are unchanged

https://claude.ai/code/session_01Dxbo7Ja3sEquc6fSMc4WaY

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dxbo7Ja3sEquc6fSMc4WaY)_