### PR TITLE
Reject duplicate cast records and tighten phone validation in cast auth flows

### DIFF
--- a/lib/actions/cast-auth.ts
+++ b/lib/actions/cast-auth.ts
@@ -106,6 +106,13 @@ export async function castSendLoginOtp(formData: FormData) {
     };
   }
 
+  if (candidates.length > 1) {
+    return {
+      success: false,
+      error: '同一電話番号に複数のキャスト情報が見つかりました。担当者にお問い合わせください。',
+    };
+  }
+
   if (!castRecord.auth_user_id) {
     return {
       success: false,
@@ -166,7 +173,7 @@ export async function castVerifyLoginOtp(formData: FormData) {
   const normalizedPhone = normalizeCastPhone(phone);
   const authPhone = toE164JpPhone(phone);
 
-  if (!authPhone) {
+  if (!/^0\d{9,10}$/.test(normalizedPhone) || !authPhone) {
     return { success: false, error: '電話番号の形式が正しくありません。' };
   }
 
@@ -215,6 +222,20 @@ export async function castVerifyLoginOtp(formData: FormData) {
 
   if (!candidate || !castRecord) {
     return { success: false, error: 'キャスト情報との紐付けに失敗しました。担当者にお問い合わせください。' };
+  }
+
+  if (candidates.length > 1) {
+    return {
+      success: false,
+      error: '同一電話番号に複数のキャスト情報が見つかりました。担当者にお問い合わせください。',
+    };
+  }
+
+  if (castRecord.auth_user_id && castRecord.auth_user_id !== authUserId) {
+    return {
+      success: false,
+      error: 'キャスト情報の紐付け状態が不正です。担当者にお問い合わせください。',
+    };
   }
 
   const { error: castUpdateError } = await serviceRoleClient


### PR DESCRIPTION
### Motivation

- Prevent ambiguous or incorrect account linkage when multiple cast identities share the same phone number and catch malformed phone inputs earlier in the verification flow.

### Description

- Return an error if `findCastIdentityByPhone` returns more than one candidate in both `castSendLoginOtp` and `castVerifyLoginOtp`.
- Add normalized phone format validation (`/^0\d{9,10}$/`) to `castVerifyLoginOtp` to mirror the send flow.
- Add a guard that rejects verification when an existing `castRecord.auth_user_id` is present and does not match the verified `authUserId` to avoid mismatched associations.
- Adjust error messages to surface these new failure cases to callers.

### Testing

- Ran the project test suite with `yarn test` and the auth-related tests, and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb21d119c88321b1cb677646b51e38)