### PR TITLE
fix(cast-auth): support E.164 phone matching in SMS login

### DIFF
--- a/lib/actions/cast-auth.ts
+++ b/lib/actions/cast-auth.ts
@@ -19,11 +19,11 @@ import { redirect } from 'next/navigation';
 import { revalidatePath } from 'next/cache';
 
 async function findCastIdentityByPhone(serviceRoleClient: ReturnType<typeof createServiceClient>, normalizedPhone: string) {
-  // DBには数字のみ形式と旧ハイフン付き形式が混在している可能性があるため両方で検索
+  // DBには数字のみ形式・ハイフン付き形式・E.164形式が混在している可能性があるため全形式で検索
   const formattedPhone = formatJapaneseMobilePhone(normalizedPhone);
-  const phonesToSearch = formattedPhone !== normalizedPhone
-    ? [normalizedPhone, formattedPhone]
-    : [normalizedPhone];
+  const e164Phone = `+81${normalizedPhone.slice(1)}`;  // +817012343590
+  const e164NoPlus = `81${normalizedPhone.slice(1)}`;  // 817012343590
+  const phonesToSearch = Array.from(new Set([normalizedPhone, formattedPhone, e164Phone, e164NoPlus]));
 
   const { data, error } = await serviceRoleClient
     .from('cast_private_info')


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Expands `findCastIdentityByPhone` to search `cast_private_info.phone` across all four storage variants: local digits (`07012345678`), hyphenated (`070-1234-5678`), E.164 (`+817012345678`), and 81-prefix (`817012345678`)
- Fixes the root cause where phones stored as `+81...` or `81...` in the DB caused `「この電話番号は事前登録されていません」` when a cast entered their number in local Japanese format
- All existing security guards preserved: `auth_user_id` mismatch check, OTP-before-linking, first-login SMS requirement

## Root Cause

`cast_private_info.phone` may be stored in any of four formats depending on how the record was originally inserted. The previous code only searched local-digits and hyphenated formats, missing E.164 variants.

## Changed Files

- `lib/actions/cast-auth.ts` — `findCastIdentityByPhone`: +2 lines (e164Phone, e164NoPlus), replace conditional array with `Array.from(new Set([...]))`

## Test Plan

- [ ] Manual DB read-only check: confirm test cast `田中みさと` record exists in `cast_private_info` with phone ending `3590`
- [ ] Check `casts.auth_user_id` is non-null (post-register) before OTP test
- [ ] Check `last_sms_verified_at` is null before first OTP
- [ ] Open https://club-animo.jp/cast/login, enter `070-****-3590`
- [ ] Confirm no `この電話番号は事前登録されていません` error
- [ ] Confirm SMS OTP sent
- [ ] Enter OTP, confirm redirect to `/cast/dashboard`
- [ ] Confirm `casts.auth_user_id` non-null and `last_sms_verified_at` updated in DB

https://claude.ai/code/session_019p5Zw5TV9YKCB6zqfU2H77
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_019p5Zw5TV9YKCB6zqfU2H77)_