### PR TITLE
fix(admin): restore sidebar and staff registration route

### DIFF
--- a/app/admin/(protected)/posts/page.tsx
+++ b/app/admin/(protected)/posts/page.tsx
@@ -6,7 +6,7 @@ import Image from 'next/image';
 import { revalidatePath } from 'next/cache';
 
 export const metadata = {
-  title: 'キャスト投稿管理 | Animo CMS',
+  title: 'キャストブログ管理 | Animo CMS',
 };
 
 export default async function AdminCastPostsPage({
@@ -62,7 +62,7 @@ export default async function AdminCastPostsPage({
     <div className="space-y-6 font-inter">
       {/* ── Page Header ── */}
       <div className="py-2">
-        <h1 className="text-[17px] font-semibold text-[#f4f1ea] tracking-[-0.31px]">キャスト投稿</h1>
+        <h1 className="text-[17px] font-semibold text-[#f4f1ea] tracking-[-0.31px]">キャストブログ</h1>
         <p className="text-[11px] text-[#8a8478] tracking-[0.06px] mt-0.5">キャストの日記投稿を管理・承認します</p>
       </div>
 

--- a/app/admin/(protected)/settings/page.tsx
+++ b/app/admin/(protected)/settings/page.tsx
@@ -1,3 +1,5 @@
+import Link from 'next/link'
+import { ImageIcon, Grid3X3, Palette, ChevronRight, type LucideIcon } from 'lucide-react'
 import { getSiteSettings } from '@/lib/actions/contents'
 import { getLineNotifications, getLinkedCasts } from '@/lib/actions/line-notifications'
 import { SettingsForm } from '@/components/features/admin/SettingsForm'
@@ -41,6 +43,36 @@ export default async function SettingsPage() {
           />
         </section>
       </div>
+
+      {/* ── デザイン管理 ── */}
+      <section>
+        <div className="mb-6">
+          <h2 className="text-[14px] font-bold tracking-[2px] text-[#f4f1ea] uppercase">デザイン管理</h2>
+          <p className="text-[11px] text-[#8a8478] mt-1">ヒーロービジュアル・ギャラリーなどのビジュアル設定を管理します</p>
+        </div>
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+          {([
+            { href: '/admin/design',   Icon: Palette,   title: 'デザイン管理',   sub: 'デザイン設定の一覧と各管理ページへ移動します' },
+            { href: '/admin/hero',     Icon: ImageIcon, title: 'ヒーロー管理',   sub: 'トップページのヒーロービジュアルと表示テキストを管理します' },
+            { href: '/admin/gallery',  Icon: Grid3X3,   title: 'ギャラリー管理', sub: 'ギャラリーセクションに表示する画像を管理します' },
+          ] as { href: string; Icon: LucideIcon; title: string; sub: string }[]).map((item) => (
+            <Link
+              key={item.href}
+              href={item.href}
+              className="group flex items-center gap-4 rounded-[16px] border border-[#dfbd69]/18 bg-[#17181c] px-5 py-4 transition-all hover:bg-[#1c1d22] hover:border-[#dfbd69]/30"
+            >
+              <div className="w-[38px] h-[38px] flex items-center justify-center rounded-[10px] bg-[#dfbd691a] shrink-0">
+                <item.Icon size={17} className="text-[#dfbd69]" />
+              </div>
+              <div className="flex-1 min-w-0">
+                <p className="text-[13px] font-semibold text-[#f4f1ea] leading-snug">{item.title}</p>
+                <p className="text-[11px] text-[#8a8478] mt-0.5 line-clamp-2">{item.sub}</p>
+              </div>
+              <ChevronRight size={15} className="text-[#5a5650] group-hover:text-[#dfbd69] transition-colors shrink-0" />
+            </Link>
+          ))}
+        </div>
+      </section>
     </div>
   )
 }

--- a/app/admin/(protected)/shift-requests/page.tsx
+++ b/app/admin/(protected)/shift-requests/page.tsx
@@ -93,7 +93,7 @@ export default async function ShiftRequestsPage({
             className="font-bold leading-none tracking-[-0.02em] text-[#111]"
             style={{ fontSize: 'clamp(36px, 5vw, 52px)' }}
           >
-            出勤調整＆承認
+            出勤調整・承認
           </h1>
           <p className="mt-2.5 text-[12px] text-[#6b6460] leading-relaxed">
             週次提出・変更申請・店舗募集の承認状況を確認し、既存の承認フローへ接続します。

--- a/components/layouts/AdminLayout.tsx
+++ b/components/layouts/AdminLayout.tsx
@@ -6,22 +6,22 @@ import { usePathname } from 'next/navigation';
 import {
   LayoutDashboard, Users, Calendar, Settings, MessageSquare,
   LogOut, Briefcase, Menu, ChevronRight, X, Bell, ClipboardList,
-  UserCheck, BarChart2, Palette, BookOpen, Newspaper, Moon, Sun, List, Printer,
+  UserCheck, BarChart2, BookOpen, Moon, Sun, List, Printer,
 } from 'lucide-react';
 import { logout } from '@/lib/actions/auth';
 import { AdminThemeProvider, useAdminTheme } from '@/components/providers/AdminThemeProvider';
 
 const NAV_ITEMS = [
   // ── OVERVIEW ──────────────────────────────────────────────────────────────
-  { href: '/admin/today',              icon: ClipboardList,   label: '本日の営業状況', section: 'overview' },
   { href: '/admin/dashboard',          icon: LayoutDashboard, label: 'ダッシュボード', section: 'overview' },
+  { href: '/admin/today',              icon: ClipboardList,   label: '本日の営業状況', section: 'overview' },
 
   // ── OPERATIONS ────────────────────────────────────────────────────────────
   { href: '/admin/human-resources',    icon: Users,           label: 'キャスト管理',   section: 'operations' },
-  { href: '/admin/staffs',             icon: UserCheck,       label: 'スタッフ管理',   section: 'operations' },
-  { href: '/admin/shift-requests',     icon: ClipboardList,   label: '出勤調整＆承認',       section: 'operations', badge: 'shifts' },
+  { href: '/admin/shift-requests',     icon: ClipboardList,   label: '出勤調整・承認', section: 'operations', badge: 'shifts' },
   { href: '/admin/monthly-shifts',     icon: Calendar,        label: 'シフト管理',     section: 'operations' },
   { href: '/admin/template-shifts',    icon: Printer,         label: 'シフト印刷表',   section: 'operations' },
+  { href: '/admin/staffs',             icon: UserCheck,       label: 'スタッフ管理',   section: 'operations' },
   { href: '/admin/internal-notices',   icon: Bell,            label: '通知',           section: 'operations', badge: 'notifications' },
 
   // ── CUSTOMER ──────────────────────────────────────────────────────────────
@@ -31,13 +31,11 @@ const NAV_ITEMS = [
   { href: '/admin/applications',       icon: Briefcase,       label: '求人応募',       section: 'recruitment', badge: 'applications' },
 
   // ── CONTENT ───────────────────────────────────────────────────────────────
-  { href: '/admin/posts',              icon: MessageSquare,   label: 'キャスト投稿',   section: 'content', badge: 'posts' },
-  { href: '/admin/contents',           icon: Newspaper,       label: 'ニュース',       section: 'content' },
+  { href: '/admin/posts',              icon: MessageSquare,   label: 'キャストブログ', section: 'content', badge: 'posts' },
   { href: '/admin/analytics',          icon: BarChart2,       label: 'サイト分析',     section: 'content' },
 
   // ── SYSTEM ────────────────────────────────────────────────────────────────
-  { href: '/admin/design',             icon: Palette,         label: 'デザイン',       section: 'system' },
-  { href: '/admin/settings',           icon: Settings,        label: '設定',           section: 'system', roles: ['owner', 'manager'] },
+  { href: '/admin/settings',           icon: Settings,        label: '設定・デザイン', section: 'system', roles: ['owner', 'manager'] },
   { href: '/admin/manual',             icon: BookOpen,        label: '操作マニュアル', section: 'system' },
 ];
 


### PR DESCRIPTION
## Summary

- **OVERVIEW**: ダッシュボード first, 本日の営業状況 second (was reversed)
- **OPERATIONS**: correct order (キャスト管理 → 出勤調整・承認 → シフト管理 → シフト印刷表 → スタッフ管理 → 通知); label ＆ → ・
- **CONTENT**: キャスト投稿 → キャストブログ; ニュース removed from sidebar navigation only (route `/admin/contents` preserved)
- **SYSTEM**: デザイン + 設定 merged into 設定・デザイン pointing to `/admin/settings`; Palette/Newspaper imports removed
- **Settings page**: design management card links added (→ /admin/design, /admin/hero, /admin/gallery) so design pages remain reachable
- **Posts page**: h1 and metadata title updated to キャストブログ
- **Shift-requests page**: h1 出勤調整＆承認 → 出勤調整・承認
- **Staff registration**: `/admin/human-resources/staffs/new` already present on main via PR #37 — no route change needed

## Files changed

- `components/layouts/AdminLayout.tsx`
- `app/admin/(protected)/settings/page.tsx`
- `app/admin/(protected)/shift-requests/page.tsx`
- `app/admin/(protected)/posts/page.tsx`

## Test plan

- [ ] Sidebar OVERVIEW shows ダッシュボード before 本日の営業状況
- [ ] Sidebar OPERATIONS order and ・ label correct
- [ ] ニュース absent from sidebar; `/admin/contents` still loads
- [ ] Sidebar SYSTEM shows 設定・デザイン (no separate デザイン item)
- [ ] `/admin/settings` shows デザイン管理 cards linking to /admin/design, /admin/hero, /admin/gallery
- [ ] `/admin/posts` h1 reads キャストブログ
- [ ] `/admin/shift-requests` h1 reads 出勤調整・承認
- [ ] `/admin/human-resources/staffs/new` loads without 404
- [ ] `pnpm lint` — 0 errors
- [ ] `pnpm build` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)