### PR TITLE
feat(admin): manual daily cast attendance override (Phase 1)

### DIFF
--- a/components/features/admin/dashboard/DashboardTodayShifts.tsx
+++ b/components/features/admin/dashboard/DashboardTodayShifts.tsx
@@ -1,155 +1,85 @@
-import { getDashboardCastShifts } from '@/lib/actions/dashboard';
-import Link from 'next/link';
-import { DashboardEmptyState } from './DashboardEmptyState';
-import { ChevronRight, Users } from 'lucide-react';
-
-const STATUS_CONFIG = {
-  confirmed: {
-    label: '確定',
-    bg: 'bg-[#50a06414]',
-    border: 'border-[#50a0642e]',
-    textColor: 'text-[#72b894]',
-    dot: 'bg-[#72b894]',
-  },
-  late: {
-    label: '予定遅刻',
-    bg: 'bg-[#c8823214]',
-    border: 'border-[#c882322e]',
-    textColor: 'text-[#c8884d]',
-    dot: 'bg-[#c8884d]',
-  },
-  trial: {
-    label: '体験入店',
-    bg: 'bg-[#dfbd6914]',
-    border: 'border-[#dfbd692e]',
-    textColor: 'text-[#dfbd69]',
-    dot: 'bg-[#dfbd69]',
-  },
-  pending: {
-    label: '確認待ち',
-    bg: 'bg-[#8a847814]',
-    border: 'border-[#8a84782e]',
-    textColor: 'text-[#8a8478]',
-    dot: 'bg-[#8a8478]',
-  },
-} as const;
+import { getDashboardCastShifts } from '@/lib/actions/dashboard'
+import Link from 'next/link'
+import { DashboardEmptyState } from './DashboardEmptyState'
+import { DashboardTodayShiftsRow } from './DashboardTodayShiftsRow'
+import { ChevronRight, Users } from 'lucide-react'
 
 export async function DashboardTodayShifts() {
-  const casts = await getDashboardCastShifts();
+  const casts = await getDashboardCastShifts()
 
-  const confirmedCount = casts.filter((c) => c.status === 'confirmed').length;
-  const lateCount = casts.filter((c) => c.status === 'late').length;
-  const trialCount = casts.filter((c) => c.status === 'trial').length;
+  const workingCount = casts.filter(
+    (c) => c.status === 'working' || c.status === 'confirmed'
+  ).length
+  const absentCount = casts.filter((c) => c.status === 'absent').length
+  const lateCount = casts.filter((c) => c.status === 'late').length
+  const trialCount = casts.filter((c) => c.status === 'trial').length
+
+  const summaryParts: string[] = [`出勤 ${workingCount}名`]
+  if (absentCount > 0) summaryParts.push(`欠勤 ${absentCount}名`)
+  if (lateCount > 0) summaryParts.push(`遅刻 ${lateCount}名`)
+  if (trialCount > 0) summaryParts.push(`体験 ${trialCount}名`)
 
   return (
     <div className="flex flex-col rounded-[18px] font-sans h-full card-premium-skin">
       <div className="card-premium-skin__surface flex flex-col flex-1 overflow-hidden rounded-[18px]">
-      {/* Header */}
-      <div className="flex items-center justify-between px-6 h-[56px] border-b border-[#ffffff0f] shrink-0">
-        <div className="flex items-center gap-3">
-          <div className="w-[33px] h-[33px] flex items-center justify-center bg-[#dfbd691a] rounded-[7px] shrink-0">
-            <Users size={15} className="text-[#dfbd69]" strokeWidth={2.5} />
+        {/* Header */}
+        <div className="flex items-center justify-between px-6 h-[56px] border-b border-[#ffffff0f] shrink-0">
+          <div className="flex items-center gap-3">
+            <div className="w-[33px] h-[33px] flex items-center justify-center bg-[#dfbd691a] rounded-[7px] shrink-0">
+              <Users size={15} className="text-[#dfbd69]" strokeWidth={2.5} />
+            </div>
+            <div className="flex flex-col">
+              <p className="text-[13px] font-bold text-[#f4f1ea] tracking-[-0.08px] leading-tight">
+                本日の出勤キャスト
+              </p>
+              <p className="text-[11px] text-[#8a8478] tracking-[0.06px] leading-tight">
+                {summaryParts.join(' / ')}
+              </p>
+            </div>
           </div>
-          <div className="flex flex-col">
-            <p className="text-[13px] font-bold text-[#f4f1ea] tracking-[-0.08px] leading-tight">本日の出勤キャスト</p>
-            <p className="text-[11px] text-[#8a8478] tracking-[0.06px] leading-tight">
-              確定 {confirmedCount}名
-              {lateCount > 0 && ` / 遅刻 ${lateCount}名`}
-              {trialCount > 0 && ` / 体験 ${trialCount}名`}
-            </p>
-          </div>
+          <Link
+            href="/admin/today"
+            className="flex items-center gap-2 px-5 h-[40px] rounded-[10px] bg-white/4 border border-gold/40 text-[12px] font-bold text-[#dfbd69] hover:bg-[#dfbd6910] transition-all"
+          >
+            <span>詳細を表示</span>
+            <ChevronRight size={14} />
+          </Link>
         </div>
-        <Link
-          href="/admin/today"
-          className="flex items-center gap-2 px-5 h-[40px] rounded-[10px] bg-white/4 border border-gold/40 text-[12px] font-bold text-[#dfbd69] hover:bg-[#dfbd6910] transition-all"
-        >
-          <span>詳細を表示</span>
-          <ChevronRight size={14} />
-        </Link>
-      </div>
 
-      {/* Table */}
-      {casts.length === 0 ? (
-        <div className="flex-1 p-5">
-          <DashboardEmptyState className="min-h-[200px] h-full" />
-        </div>
-      ) : (
-      <div className="flex-1 overflow-x-auto custom-scrollbar">
-        <div className="min-w-[900px]">
-          {/* Table Header Row */}
-          <div className="flex items-center h-[42px] border-t border-b border-[#ffffff0a] px-6 bg-white/1">
-            <div className="w-[240px] text-[9px] font-bold tracking-[1px] text-[#5a5650] uppercase">CAST NAME</div>
-            <div className="w-section text-[9px] font-bold tracking-[1px] text-[#5a5650] uppercase px-4">SHIFT TIME</div>
-            <div className="w-[120px] text-[9px] font-bold tracking-[1px] text-[#5a5650] uppercase text-center">STATUS</div>
-            <div className="flex-1 text-[9px] font-bold tracking-[1px] text-[#5a5650] uppercase px-4">MEMO / TAGS</div>
+        {/* Table */}
+        {casts.length === 0 ? (
+          <div className="flex-1 p-5">
+            <DashboardEmptyState className="min-h-[200px] h-full" />
           </div>
+        ) : (
+          <div className="flex-1 overflow-x-auto custom-scrollbar">
+            <div className="min-w-[960px]">
+              {/* Table Header Row */}
+              <div className="flex items-center h-[42px] border-t border-b border-[#ffffff0a] px-6 bg-white/1">
+                <div className="w-[240px] text-[9px] font-bold tracking-[1px] text-[#5a5650] uppercase">
+                  CAST NAME
+                </div>
+                <div className="w-section text-[9px] font-bold tracking-[1px] text-[#5a5650] uppercase px-6">
+                  SHIFT TIME
+                </div>
+                <div className="w-[220px] text-[9px] font-bold tracking-[1px] text-[#5a5650] uppercase">
+                  ATTENDANCE
+                </div>
+                <div className="flex-1 text-[9px] font-bold tracking-[1px] text-[#5a5650] uppercase px-4">
+                  MEMO / TAGS
+                </div>
+              </div>
 
-          {/* Table Body */}
-          <div className="divide-y divide-[#ffffff0a]">
-            {casts.map((cast) => {
-                const cfg = STATUS_CONFIG[cast.status] || STATUS_CONFIG.pending;
-                return (
-                  <div
-                    key={cast.castId}
-                    className="flex items-center min-h-[52px] hover:bg-white/2 transition-colors px-6"
-                  >
-                    <div className="w-[240px] flex items-center gap-3 shrink-0">
-                      <div className="w-10 h-10 rounded-full bg-[#1c1d22] border border-[#ffffff0a] flex items-center justify-center shrink-0 overflow-hidden relative shadow-2xl">
-                        {cast.avatarUrl ? (
-                           <img 
-                             src={cast.avatarUrl} 
-                             alt={cast.castName} 
-                             className="w-full h-full object-cover" 
-                             referrerPolicy="no-referrer"
-                           />
-                        ) : (
-                          <span className="text-[11px] font-bold text-[#5a5650]">{cast.initial}</span>
-                        )}
-                        <div className="absolute inset-0 ring-1 ring-inset ring-white/10 rounded-full" />
-                      </div>
-                      <span className="text-[14px] font-bold text-[#f4f1ea] tracking-tight">{cast.castName}</span>
-                    </div>
-                    
-                    {/* Time */}
-                    <div className="w-section px-6">
-                      <div className="inline-flex items-center gap-2 text-[14px] font-bold text-gold font-sans bg-gold/5 px-3 py-1.5 rounded-[6px] border border-gold/10">
-                        <span>{cast.startTime}</span>
-                        <span className="text-[#5a5650] font-normal opacity-50">—</span>
-                        <span className="text-[#8a8478] font-medium">{cast.endTime || '—'}</span>
-                      </div>
-                    </div>
-
-                    {/* Status Badge */}
-                    <div className="w-[140px] flex justify-center">
-                      <div className={`flex items-center gap-2 px-4 py-1.5 ${cfg.bg} rounded-full border ${cfg.border} min-w-[90px] justify-center shadow-lg shadow-black/20`}>
-                        <div className={`w-[6px] h-[6px] rounded-full ${cfg.dot}`} />
-                        <span className={`font-sans text-[10px] font-bold tracking-[0.117px] leading-[14px] uppercase ${cfg.textColor}`}>{cfg.label}</span>
-                      </div>
-                    </div>
-
-                    {/* Tags */}
-                    <div className="flex-1 px-4 flex flex-wrap gap-2">
-                      {cast.tags.length > 0 ? (
-                        cast.tags.map((tag, i) => (
-                          <span
-                             key={i}
-                             className="px-2.5 py-1 bg-white/3 border border-white/5 rounded-[6px] font-sans text-[10px] font-semibold text-[#8a8478] tracking-[0.117px] leading-[14px] hover:text-[#dfbd69] transition-colors"
-                          >
-                            {tag}
-                          </span>
-                        ))
-                      ) : (
-                        <span className="text-[11px] text-[#5a5650] tracking-widest opacity-40">—</span>
-                      )}
-                    </div>
-                  </div>
-                );
-              })}
+              {/* Table Body */}
+              <div className="divide-y divide-[#ffffff0a]">
+                {casts.map((cast) => (
+                  <DashboardTodayShiftsRow key={cast.castId} cast={cast} />
+                ))}
+              </div>
+            </div>
           </div>
-        </div>
-      </div>
-      )}
+        )}
       </div>
     </div>
-  );
+  )
 }

--- a/components/features/admin/dashboard/DashboardTodayShiftsRow.tsx
+++ b/components/features/admin/dashboard/DashboardTodayShiftsRow.tsx
@@ -1,0 +1,196 @@
+'use client'
+
+import { useOptimistic, useTransition } from 'react'
+import { updateDailyCastAttendance } from '@/lib/actions/today'
+import type { DashboardCastShift, ManualAttendanceStatus } from '@/lib/actions/dashboard'
+
+// ──────────────────────────────────────────────────────
+// Status badge config — includes manual override states
+// ──────────────────────────────────────────────────────
+const STATUS_CONFIG = {
+  confirmed: {
+    label: '確定',
+    bg: 'bg-[#50a06414]',
+    border: 'border-[#50a0642e]',
+    textColor: 'text-[#72b894]',
+    dot: 'bg-[#72b894]',
+  },
+  working: {
+    label: '出勤',
+    bg: 'bg-[#50a06414]',
+    border: 'border-[#50a0642e]',
+    textColor: 'text-[#72b894]',
+    dot: 'bg-[#72b894]',
+  },
+  late: {
+    label: '予定遅刻',
+    bg: 'bg-[#c8823214]',
+    border: 'border-[#c882322e]',
+    textColor: 'text-[#c8884d]',
+    dot: 'bg-[#c8884d]',
+  },
+  trial: {
+    label: '体験入店',
+    bg: 'bg-[#dfbd6914]',
+    border: 'border-[#dfbd692e]',
+    textColor: 'text-[#dfbd69]',
+    dot: 'bg-[#dfbd69]',
+  },
+  absent: {
+    label: '欠勤',
+    bg: 'bg-[#e05c5c14]',
+    border: 'border-[#e05c5c2e]',
+    textColor: 'text-[#e08080]',
+    dot: 'bg-[#e08080]',
+  },
+  pending: {
+    label: '確認待ち',
+    bg: 'bg-[#8a847814]',
+    border: 'border-[#8a84782e]',
+    textColor: 'text-[#8a8478]',
+    dot: 'bg-[#8a8478]',
+  },
+} as const
+
+const SOURCE_LABEL: Record<string, string> = {
+  manual: '手動変更',
+  checkin: '今日の回答',
+  shift: 'シフト申請',
+  none: '',
+}
+
+// ──────────────────────────────────────────────────────
+// Row component
+// ──────────────────────────────────────────────────────
+export function DashboardTodayShiftsRow({ cast }: { cast: DashboardCastShift }) {
+  const [isPending, startTransition] = useTransition()
+  const [optimisticManual, setOptimisticManual] = useOptimistic<ManualAttendanceStatus>(
+    cast.manualStatus
+  )
+
+  const isTrial = cast.castId.startsWith('trial-')
+
+  function handleOverride(status: ManualAttendanceStatus): void {
+    if (isTrial) return
+    setOptimisticManual(status)
+    startTransition(async () => {
+      await updateDailyCastAttendance({ castId: cast.castId, status })
+    })
+  }
+
+  const cfg = STATUS_CONFIG[cast.status] ?? STATUS_CONFIG.pending
+  const sourceLabel = SOURCE_LABEL[cast.finalStatusSource] ?? ''
+
+  return (
+    <div
+      className={`flex items-center min-h-[60px] hover:bg-white/2 transition-colors px-6 ${isPending ? 'opacity-70' : ''}`}
+    >
+      {/* Cast name */}
+      <div className="w-[240px] flex items-center gap-3 shrink-0">
+        <div className="w-10 h-10 rounded-full bg-[#1c1d22] border border-[#ffffff0a] flex items-center justify-center shrink-0 overflow-hidden relative shadow-2xl">
+          {cast.avatarUrl ? (
+            <img
+              src={cast.avatarUrl}
+              alt={cast.castName}
+              className="w-full h-full object-cover"
+              referrerPolicy="no-referrer"
+            />
+          ) : (
+            <span className="text-[11px] font-bold text-[#5a5650]">{cast.initial}</span>
+          )}
+          <div className="absolute inset-0 ring-1 ring-inset ring-white/10 rounded-full" />
+        </div>
+        <span className="text-[14px] font-bold text-[#f4f1ea] tracking-tight">{cast.castName}</span>
+      </div>
+
+      {/* Shift time */}
+      <div className="w-section px-6 shrink-0">
+        <div className="inline-flex items-center gap-2 text-[14px] font-bold text-gold font-sans bg-gold/5 px-3 py-1.5 rounded-[6px] border border-gold/10">
+          <span>{cast.startTime}</span>
+          <span className="text-[#5a5650] font-normal opacity-50">—</span>
+          <span className="text-[#8a8478] font-medium">{cast.endTime || '—'}</span>
+        </div>
+      </div>
+
+      {/* Attendance status + manual override controls */}
+      <div className="w-[220px] shrink-0 flex flex-col gap-2 py-2">
+        {/* Status badge + source */}
+        <div className="flex items-center gap-2 flex-wrap">
+          <div
+            className={`flex items-center gap-1.5 px-3 py-1 ${cfg.bg} rounded-full border ${cfg.border} shadow-sm`}
+          >
+            <div className={`w-[5px] h-[5px] rounded-full ${cfg.dot}`} />
+            <span className={`font-sans text-[10px] font-bold tracking-[0.1px] leading-[14px] ${cfg.textColor}`}>
+              {cfg.label}
+            </span>
+          </div>
+          {sourceLabel && (
+            <span className="text-[9px] text-[#5a5650] tracking-wide font-medium">{sourceLabel}</span>
+          )}
+        </div>
+
+        {/* Override buttons — hidden for trial entries */}
+        {!isTrial && (
+          <div className="flex items-center gap-1">
+            <button
+              type="button"
+              onClick={() => handleOverride('working')}
+              disabled={isPending}
+              aria-pressed={optimisticManual === 'working'}
+              className={`text-[10px] font-bold px-2.5 py-1.5 rounded-[5px] border transition-all min-h-[28px] min-w-[44px] ${
+                optimisticManual === 'working'
+                  ? 'bg-[#72b89420] border-[#72b89450] text-[#72b894]'
+                  : 'bg-white/3 border-white/8 text-[#5a5650] hover:text-[#72b894] hover:border-[#72b89430] hover:bg-[#72b89410]'
+              } disabled:cursor-not-allowed`}
+            >
+              出勤
+            </button>
+            <button
+              type="button"
+              onClick={() => handleOverride('absent')}
+              disabled={isPending}
+              aria-pressed={optimisticManual === 'absent'}
+              className={`text-[10px] font-bold px-2.5 py-1.5 rounded-[5px] border transition-all min-h-[28px] min-w-[44px] ${
+                optimisticManual === 'absent'
+                  ? 'bg-[#e0808020] border-[#e0808050] text-[#e08080]'
+                  : 'bg-white/3 border-white/8 text-[#5a5650] hover:text-[#e08080] hover:border-[#e0808030] hover:bg-[#e0808010]'
+              } disabled:cursor-not-allowed`}
+            >
+              欠勤
+            </button>
+            <button
+              type="button"
+              onClick={() => handleOverride('undecided')}
+              disabled={isPending}
+              aria-pressed={optimisticManual === 'undecided'}
+              title="手動変更をリセット"
+              className={`text-[10px] font-bold px-2.5 py-1.5 rounded-[5px] border transition-all min-h-[28px] min-w-[28px] ${
+                optimisticManual === 'undecided'
+                  ? 'bg-white/5 border-white/15 text-[#8a8478]'
+                  : 'bg-white/2 border-white/5 text-[#3a3830] hover:text-[#8a8478] hover:border-white/15'
+              } disabled:cursor-not-allowed`}
+            >
+              —
+            </button>
+          </div>
+        )}
+      </div>
+
+      {/* Tags */}
+      <div className="flex-1 px-4 flex flex-wrap gap-2 items-center">
+        {cast.tags.length > 0 ? (
+          cast.tags.map((tag, i) => (
+            <span
+              key={i}
+              className="px-2.5 py-1 bg-white/3 border border-white/5 rounded-[6px] font-sans text-[10px] font-semibold text-[#8a8478] tracking-[0.117px] leading-[14px] hover:text-[#dfbd69] transition-colors"
+            >
+              {tag}
+            </span>
+          ))
+        ) : (
+          <span className="text-[11px] text-[#5a5650] tracking-widest opacity-40">—</span>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/lib/actions/dashboard.ts
+++ b/lib/actions/dashboard.ts
@@ -45,16 +45,22 @@ export type DashboardReservation = {
   reservationType: string;
 };
 
+export type ManualAttendanceStatus = 'working' | 'absent' | 'undecided'
+export type FinalStatusSource = 'manual' | 'checkin' | 'shift' | 'none'
+
 export type DashboardCastShift = {
-  castId: string;
-  castName: string;
-  initial: string;
-  startTime: string;
-  endTime?: string;
-  status: 'confirmed' | 'late' | 'trial' | 'pending';
-  tags: string[];
-  avatarUrl?: string;
-};
+  castId: string
+  castName: string
+  initial: string
+  startTime: string
+  endTime?: string
+  status: 'confirmed' | 'late' | 'trial' | 'pending' | 'working' | 'absent'
+  tags: string[]
+  avatarUrl?: string
+  manualStatus: ManualAttendanceStatus
+  manualNote: string | null
+  finalStatusSource: FinalStatusSource
+}
 
 export type DashboardCastRanking = {
   rank: number;
@@ -290,14 +296,15 @@ export async function getDashboardReservations(): Promise<DashboardReservation[]
 // 本日の出勤キャスト（Figmaデザイン版）
 // ─────────────────────────────────────────────
 export async function getDashboardCastShifts(): Promise<DashboardCastShift[]> {
-  const supabase = createServiceClient();
-  const today = getJstDateString();
+  const supabase = createServiceClient()
+  const today = getJstDateString()
 
   const [
     { data: shiftsRaw },
     { data: checkinsRaw },
     { data: trials },
     { data: postsRaw },
+    { data: manualRaw },
   ] = await Promise.all([
     supabase.from('shift_submissions').select('cast_id, shifts_data, casts(stage_name, profile_image_url)').eq('status', 'approved'),
     supabase.from('daily_checkins').select('cast_id, is_absent, has_change, change_note').eq('checkin_date', today),
@@ -307,38 +314,62 @@ export async function getDashboardCastShifts(): Promise<DashboardCastShift[]> {
       .select('cast_id, created_at')
       .gte('created_at', new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString())
       .eq('status', 'approved'),
-  ]);
+    supabase
+      .from('daily_cast_attendance')
+      .select('cast_id, status, note')
+      .eq('business_date', today),
+  ])
 
-  const checkinMap = new Map((checkinsRaw || []).map(c => [c.cast_id, c]));
-  const recentPostCastIds = new Set((postsRaw || []).map(p => p.cast_id));
+  const checkinMap = new Map((checkinsRaw || []).map(c => [c.cast_id, c]))
+  const recentPostCastIds = new Set((postsRaw || []).map(p => p.cast_id))
+  const manualMap = new Map(
+    (manualRaw || []).map(m => [m.cast_id, { status: m.status as ManualAttendanceStatus, note: m.note as string | null }])
+  )
 
-  const results: DashboardCastShift[] = [];
+  const results: DashboardCastShift[] = []
 
-  // 承認済シフトから本日出勤キャストを抽出
+  // 承認済シフトから本日出勤キャストを抽出（欠勤フィルタなし — manual override で表示制御）
   if (shiftsRaw) {
     for (const row of shiftsRaw) {
-      const d = row.shifts_data as Record<string, { type: string; start: string; end: string }>;
-      if (d[today]?.type !== 'work') continue;
+      const d = row.shifts_data as Record<string, { type: string; start: string; end: string }>
+      if (d[today]?.type !== 'work') continue
 
-      // Supabaseの結合データからキャスト情報を取得
-      const castRaw = row.casts as unknown as { stage_name: string; profile_image_url?: string } | null;
-      const castName = castRaw?.stage_name ?? '不明';
-      const avatarUrl = castRaw?.profile_image_url ?? undefined;
-      
-      const checkin = checkinMap.get(row.cast_id);
-      const isAbsent = checkin?.is_absent ?? false;
-      const hasChange = checkin?.has_change ?? false;
+      const castRaw = row.casts as unknown as { stage_name: string; profile_image_url?: string } | null
+      const castName = castRaw?.stage_name ?? '不明'
+      const avatarUrl = castRaw?.profile_image_url ?? undefined
 
-      if (isAbsent) continue;
+      const manual = manualMap.get(row.cast_id)
+      const checkin = checkinMap.get(row.cast_id)
 
-      let status: DashboardCastShift['status'] = 'pending';
-      if (checkin && !isAbsent) {
-        status = hasChange ? 'late' : 'confirmed';
+      // 最終出勤状態の優先順位:
+      //   1. manual working/absent (firm override)
+      //   2. daily_checkins (cast self-report)
+      //   3. shift exists → pending
+      //   4. undecided
+      let status: DashboardCastShift['status']
+      let finalStatusSource: FinalStatusSource
+
+      if (manual && (manual.status === 'working' || manual.status === 'absent')) {
+        status = manual.status
+        finalStatusSource = 'manual'
+      } else if (checkin) {
+        if (checkin.is_absent) {
+          status = 'absent'
+        } else if (checkin.has_change) {
+          status = 'late'
+        } else {
+          status = 'confirmed'
+        }
+        finalStatusSource = 'checkin'
+      } else {
+        status = 'pending'
+        finalStatusSource = 'shift'
       }
 
-      const tags: string[] = [];
-      if (recentPostCastIds.has(row.cast_id)) tags.push('ブログ更新済');
-      if (status === 'late') tags.push('確認必要');
+      const tags: string[] = []
+      if (recentPostCastIds.has(row.cast_id)) tags.push('ブログ更新済')
+      if (status === 'late') tags.push('確認必要')
+      if (status === 'absent') tags.push('欠勤')
 
       results.push({
         castId: row.cast_id,
@@ -349,11 +380,14 @@ export async function getDashboardCastShifts(): Promise<DashboardCastShift[]> {
         status,
         tags,
         avatarUrl,
-      });
+        manualStatus: manual?.status ?? 'undecided',
+        manualNote: manual?.note ?? null,
+        finalStatusSource,
+      })
     }
   }
 
-  // 体験入店
+  // 体験入店（manual override 対象外）
   for (const trial of (trials || [])) {
     results.push({
       castId: `trial-${trial.id}`,
@@ -362,11 +396,14 @@ export async function getDashboardCastShifts(): Promise<DashboardCastShift[]> {
       startTime: trial.start_time?.substring(0, 5) ?? '20:00',
       status: 'trial',
       tags: ['初回体入'],
-    });
+      manualStatus: 'undecided',
+      manualNote: null,
+      finalStatusSource: 'none',
+    })
   }
 
-  results.sort((a, b) => a.startTime.localeCompare(b.startTime));
-  return results;
+  results.sort((a, b) => a.startTime.localeCompare(b.startTime))
+  return results
 }
 
 // ─────────────────────────────────────────────

--- a/lib/actions/today.ts
+++ b/lib/actions/today.ts
@@ -8,6 +8,7 @@ import { revalidatePath } from 'next/cache'
 import { StaffSlave } from './staffs'
 import { getAnalyticsSummary } from './analytics'
 import { isMasterAccount } from '@/lib/config/master'
+import { getAppRole, isAdminLoginRole } from '@/lib/auth/admin-roles'
 
 // 曜日の日本語変換
 const WEEKDAYS = ['日', '月', '火', '水', '木', '金', '土']
@@ -936,4 +937,48 @@ export async function getTodaySubmissionState(date: Date = new Date()) {
     isClosed: isTodaySubmissionClosed(date),
     deadlineLabel: getTodaySubmissionDeadlineLabel(),
   }
+}
+
+// ==========================================
+// 管理者: 本日のキャスト出勤手動オーバーライド
+// ==========================================
+
+export type DailyCastAttendanceStatus = 'working' | 'absent' | 'undecided'
+
+export async function updateDailyCastAttendance(input: {
+  castId: string
+  status: DailyCastAttendanceStatus
+  note?: string | null
+}): Promise<{ success: boolean; error?: string }> {
+  const supabase = await createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) return { success: false, error: 'Unauthorized' }
+
+  const role = await getAppRole(supabase, user.id)
+  if (!isAdminLoginRole(role)) return { success: false, error: 'Forbidden' }
+
+  const today = getJstDateString()
+
+  const { error } = await supabase
+    .from('daily_cast_attendance')
+    .upsert(
+      {
+        cast_id: input.castId,
+        business_date: today,
+        status: input.status,
+        source: 'manual',
+        note: input.note ?? null,
+        updated_by: user.id,
+      },
+      { onConflict: 'cast_id,business_date' }
+    )
+
+  if (error) {
+    console.error('[updateDailyCastAttendance]', error)
+    return { success: false, error: error.message }
+  }
+
+  revalidatePath('/admin/dashboard')
+  revalidatePath('/admin/today')
+  return { success: true }
 }

--- a/supabase/migrations/20260426000001_add_daily_cast_attendance.sql
+++ b/supabase/migrations/20260426000001_add_daily_cast_attendance.sql
@@ -1,0 +1,84 @@
+-- ==========================================
+-- 本日のキャスト出勤手動オーバーライドテーブル
+-- Phase 1: Manual Daily Cast Attendance Override
+-- ==========================================
+--
+-- 目的: 管理者・スタッフが本日のキャスト出勤状況を手動で記録・上書きするための独立テーブル。
+-- 重要: daily_checkins / shift_submissions / cast_schedules は一切変更しない。
+-- 最終出勤状態の優先順位:
+--   1. daily_cast_attendance (このテーブル, status=working|absent)
+--   2. daily_checkins (キャスト自己申告)
+--   3. shift_submissions (シフト申請)
+--   4. 未確定
+--
+-- RLSパターン: 20260319000000_add_today_dashboard.sql に準拠 (user_roles.user_id)
+-- ==========================================
+
+CREATE TABLE IF NOT EXISTS public.daily_cast_attendance (
+  id            uuid        PRIMARY KEY DEFAULT uuid_generate_v4(),
+  cast_id       uuid        NOT NULL REFERENCES public.casts(id) ON DELETE CASCADE,
+  business_date date        NOT NULL DEFAULT CURRENT_DATE,
+  status        text        NOT NULL DEFAULT 'undecided'
+                  CHECK (status IN ('working', 'absent', 'undecided')),
+  source        text        NOT NULL DEFAULT 'manual'
+                  CHECK (source IN ('manual')),
+  note          text,
+  created_by    uuid        REFERENCES auth.users(id) ON DELETE SET NULL,
+  updated_by    uuid        REFERENCES auth.users(id) ON DELETE SET NULL,
+  created_at    timestamptz NOT NULL DEFAULT now(),
+  updated_at    timestamptz NOT NULL DEFAULT now(),
+
+  CONSTRAINT daily_cast_attendance_unique UNIQUE (cast_id, business_date)
+);
+
+ALTER TABLE public.daily_cast_attendance ENABLE ROW LEVEL SECURITY;
+
+-- 管理者・スタッフ: フルアクセス（user_rolesパターン準拠）
+CREATE POLICY "Admins can manage daily_cast_attendance"
+  ON public.daily_cast_attendance TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.user_roles
+      WHERE user_roles.user_id = auth.uid()
+        AND user_roles.role IN ('owner', 'manager', 'staff')
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM public.user_roles
+      WHERE user_roles.user_id = auth.uid()
+        AND user_roles.role IN ('owner', 'manager', 'staff')
+    )
+  );
+
+-- キャスト: 自分のレコードのみ参照可（書き込み不可）
+CREATE POLICY "Casts can view own attendance override"
+  ON public.daily_cast_attendance FOR SELECT TO authenticated
+  USING (
+    cast_id IN (
+      SELECT id FROM public.casts WHERE casts.auth_user_id = auth.uid()
+    )
+  );
+
+-- インデックス
+CREATE INDEX IF NOT EXISTS idx_daily_cast_attendance_cast_id
+  ON public.daily_cast_attendance(cast_id);
+
+CREATE INDEX IF NOT EXISTS idx_daily_cast_attendance_date
+  ON public.daily_cast_attendance(business_date);
+
+-- updated_at 自動更新トリガー
+CREATE OR REPLACE FUNCTION update_daily_cast_attendance_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_daily_cast_attendance_updated_at
+  ON public.daily_cast_attendance;
+
+CREATE TRIGGER trg_daily_cast_attendance_updated_at
+  BEFORE UPDATE ON public.daily_cast_attendance
+  FOR EACH ROW EXECUTE FUNCTION update_daily_cast_attendance_updated_at();


### PR DESCRIPTION
## Summary

- Adds `daily_cast_attendance` table as a manual override layer — **does not modify** `daily_checkins`, `shift_submissions`, or `cast_schedules`
- Implements `updateDailyCastAttendance()` server action with `owner / manager / staff` role guard (`cast` users blocked)
- Extends `getDashboardCastShifts()` to apply final attendance priority (manual override → today response → shift → undecided)
- Adds `DashboardTodayShiftsRow` client component with optimistic 出勤 / 欠勤 / リセット controls per cast row
- Absent casts are now visible in the dashboard with their correct final status (previously filtered out entirely)

## Database migration

**File:** `supabase/migrations/20260426000001_add_daily_cast_attendance.sql`

| Column | Type | Notes |
|--------|------|-------|
| `cast_id` | uuid FK → casts | |
| `business_date` | date | |
| `status` | text | `working \| absent \| undecided` |
| `source` | text | constrained to `'manual'` |
| `note` | text | nullable |
| `updated_by` | uuid FK → auth.users | |
| UNIQUE | `(cast_id, business_date)` | one record per cast per day |

RLS: `user_roles.user_id` pattern (matches `20260319000000_add_today_dashboard.sql`).

## Final attendance priority (applied in getDashboardCastShifts)

1. `daily_cast_attendance.status = working | absent` → firm manual override, source label: 手動変更
2. `daily_checkins` (cast self-report) → source label: 今日の回答
3. `shift_submissions` approved → pending (no checkin yet) → source label: シフト申請
4. undecided → source label: (empty)

`undecided` manual status falls through to checkin/shift — it is the reset state.

## Files changed

| File | Change |
|------|--------|
| `supabase/migrations/20260426000001_add_daily_cast_attendance.sql` | NEW |
| `lib/actions/today.ts` | Added `updateDailyCastAttendance()` + `DailyCastAttendanceStatus` type |
| `lib/actions/dashboard.ts` | Extended `DashboardCastShift` type, `getDashboardCastShifts()` now fetches manual overrides |
| `components/features/admin/dashboard/DashboardTodayShifts.tsx` | Uses `DashboardTodayShiftsRow`, updated header summary |
| `components/features/admin/dashboard/DashboardTodayShiftsRow.tsx` | NEW — client component with `useOptimistic` button controls |

**Not modified:** `daily_checkins`, `shift_submissions`, `cast_schedules`, any public-facing pages.

## Test plan

- [ ] Apply migration to Supabase
- [ ] Admin/staff can mark today's cast as 出勤 → status badge updates
- [ ] Admin/staff can mark today's cast as 欠勤 → cast visible with 欠勤 badge + 手動変更 source
- [ ] Reset (—) clears manual override → reverts to checkin/shift source
- [ ] Cast user cannot call `updateDailyCastAttendance` (Forbidden)
- [ ] Original `daily_checkins` rows unchanged after override
- [ ] Original `shift_submissions` rows unchanged after override
- [ ] Optimistic UI: button highlights immediately on click
- [ ] Mobile: horizontal scroll reaches override controls

https://claude.ai/code/session_01Ugsr3qdGWeqo4BeVfYTB7N

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ugsr3qdGWeqo4BeVfYTB7N)_