### PR TITLE
feat(admin): shift attendance management — Phase 1 & 2

### DIFF
--- a/app/admin/(protected)/shifts/page.tsx
+++ b/app/admin/(protected)/shifts/page.tsx
@@ -21,8 +21,8 @@ export default async function ShiftsPage({
         </div>
       </div>
 
-      <ShiftManager 
-        initialData={{ casts: data.casts, shifts: data.schedules, dates: data.dates }} 
+      <ShiftManager
+        initialData={{ casts: data.casts, shifts: data.schedules, dates: data.dates, dailyStaffing: data.dailyStaffing }}
         viewType={viewType}
       />
     </div>

--- a/components/features/admin/AttendanceRequestModal.tsx
+++ b/components/features/admin/AttendanceRequestModal.tsx
@@ -1,0 +1,257 @@
+'use client'
+
+import { useState, useTransition } from 'react'
+import { X, Send, Copy, Check } from 'lucide-react'
+import { sendShiftRequestNotification } from '@/lib/actions/notifications'
+import { MINIMUM_REQUIRED_CASTS } from '@/lib/config/shift-staffing'
+
+type ModalCast = { id: string; stage_name: string }
+
+type Props = {
+  date: string                    // YYYY-MM-DD
+  scheduledCount: number          // casts already on the schedule for this date
+  allCasts: ModalCast[]           // all active casts
+  scheduledCastIds: Set<string>   // cast IDs already scheduled for this date
+  onClose: () => void
+}
+
+function formatDateLabel(date: string): string {
+  const [, month, day] = date.split('-')
+  return `${parseInt(month)}月${parseInt(day)}日`
+}
+
+function buildDefaultMessage(date: string): string {
+  const [, month, day] = date.split('-')
+  return `${parseInt(month)}月${parseInt(day)}日の出勤キャストが不足しているため、出勤可能な方を探しています。\n出勤可能な場合は、アニモ公式LINEへ返信をお願いします。`
+}
+
+export function AttendanceRequestModal({
+  date,
+  scheduledCount,
+  allCasts,
+  scheduledCastIds,
+  onClose,
+}: Props) {
+  const [isPending, startTransition] = useTransition()
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(() =>
+    new Set(allCasts.filter(c => !scheduledCastIds.has(c.id)).map(c => c.id))
+  )
+  const [message, setMessage] = useState(() => buildDefaultMessage(date))
+  const [result, setResult] = useState<{ copyMessage: string; requestedCount: number; skippedCount: number } | null>(null)
+  const [copied, setCopied] = useState(false)
+
+  const shortage = Math.max(0, MINIMUM_REQUIRED_CASTS - scheduledCount)
+  const dateLabel = formatDateLabel(date)
+
+  function toggleCast(id: string): void {
+    setSelectedIds(prev => {
+      const next = new Set(prev)
+      next.has(id) ? next.delete(id) : next.add(id)
+      return next
+    })
+  }
+
+  function selectAll(): void {
+    setSelectedIds(new Set(allCasts.map(c => c.id)))
+  }
+
+  function selectNoneScheduled(): void {
+    setSelectedIds(new Set(allCasts.filter(c => !scheduledCastIds.has(c.id)).map(c => c.id)))
+  }
+
+  function handleCopy(): void {
+    if (!result) return
+    navigator.clipboard.writeText(result.copyMessage)
+    setCopied(true)
+    setTimeout(() => setCopied(false), 2000)
+  }
+
+  function handleSubmit(): void {
+    if (selectedIds.size === 0) return
+    startTransition(async () => {
+      const res = await sendShiftRequestNotification({
+        businessDate: date,
+        castIds: [...selectedIds],
+        message,
+      })
+      if (res.success) {
+        setResult({ copyMessage: res.copyMessage, requestedCount: res.requestedCount, skippedCount: res.skippedCount })
+      }
+    })
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+      {/* Backdrop */}
+      <div
+        className="absolute inset-0 bg-black/70 backdrop-blur-sm"
+        onClick={onClose}
+        aria-hidden="true"
+      />
+
+      {/* Panel */}
+      <div className="relative w-full max-w-lg bg-[#0f0f12] border border-white/10 rounded-[16px] shadow-2xl overflow-hidden max-h-[90vh] flex flex-col">
+        {/* Header */}
+        <div className="flex items-start justify-between px-6 py-4 border-b border-white/8 shrink-0">
+          <div>
+            <p className="text-[14px] font-bold text-[#f4f1ea] tracking-tight">
+              {dateLabel} — 出勤依頼
+            </p>
+            <p className="text-[11px] text-[#8a8478] mt-1">
+              出勤予定 {scheduledCount}名 / 最低 {MINIMUM_REQUIRED_CASTS}名 / 不足 {shortage}名
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="text-[#5a5650] hover:text-[#f4f1ea] transition-colors mt-0.5"
+            aria-label="閉じる"
+          >
+            <X size={18} />
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="overflow-y-auto flex-1">
+          {result ? (
+            /* ── Success state ── */
+            <div className="p-6 space-y-4">
+              <div className="flex items-center gap-2">
+                <div className="w-5 h-5 rounded-full bg-[#72b89420] border border-[#72b89440] flex items-center justify-center">
+                  <Check size={11} className="text-[#72b894]" />
+                </div>
+                <p className="text-[12px] text-[#72b894] font-bold">
+                  {result.requestedCount}名に依頼ログを記録しました
+                  {result.skippedCount > 0 && (
+                    <span className="text-[#8a8478] font-normal ml-1">（{result.skippedCount}名は重複のためスキップ）</span>
+                  )}
+                </p>
+              </div>
+
+              <p className="text-[11px] text-[#5a5650]">
+                このメッセージをコピーしてLINEから送信してください。
+              </p>
+
+              <div className="bg-black/40 border border-white/8 rounded-[10px] p-4">
+                <p className="text-[12px] text-[#f4f1ea] whitespace-pre-wrap leading-relaxed">
+                  {result.copyMessage}
+                </p>
+              </div>
+
+              <button
+                type="button"
+                onClick={handleCopy}
+                className={`w-full flex items-center justify-center gap-2 py-2.5 rounded-[8px] text-[12px] font-bold border transition-all ${
+                  copied
+                    ? 'bg-[#72b89420] border-[#72b89440] text-[#72b894]'
+                    : 'bg-white/5 border-white/10 text-[#f4f1ea] hover:bg-white/8'
+                }`}
+              >
+                {copied ? <Check size={14} /> : <Copy size={14} />}
+                {copied ? 'コピーしました' : 'メッセージをコピー'}
+              </button>
+
+              <button
+                type="button"
+                onClick={onClose}
+                className="w-full text-[11px] text-[#5a5650] hover:text-[#8a8478] transition-colors py-1"
+              >
+                閉じる
+              </button>
+            </div>
+          ) : (
+            /* ── Selection state ── */
+            <div className="p-6 space-y-5">
+              {/* Cast selection */}
+              <div>
+                <div className="flex items-center justify-between mb-2">
+                  <p className="text-[11px] font-bold text-[#8a8478] uppercase tracking-wider">
+                    依頼対象キャスト
+                  </p>
+                  <div className="flex gap-2">
+                    <button
+                      type="button"
+                      onClick={selectNoneScheduled}
+                      className="text-[10px] text-[#5a5650] hover:text-[#dfbd69] transition-colors"
+                    >
+                      未予定のみ
+                    </button>
+                    <span className="text-[#3a3830]">·</span>
+                    <button
+                      type="button"
+                      onClick={selectAll}
+                      className="text-[10px] text-[#5a5650] hover:text-[#dfbd69] transition-colors"
+                    >
+                      全員
+                    </button>
+                  </div>
+                </div>
+
+                <div className="max-h-[200px] overflow-y-auto space-y-0.5 pr-0.5">
+                  {allCasts.map(cast => {
+                    const isScheduled = scheduledCastIds.has(cast.id)
+                    const isSelected = selectedIds.has(cast.id)
+                    return (
+                      <label
+                        key={cast.id}
+                        className={`flex items-center gap-3 px-3 py-2 rounded-[8px] cursor-pointer transition-all select-none ${
+                          isSelected
+                            ? 'bg-[#dfbd6910] border border-[#dfbd6920]'
+                            : 'border border-transparent hover:bg-white/3'
+                        }`}
+                      >
+                        <input
+                          type="checkbox"
+                          checked={isSelected}
+                          onChange={() => toggleCast(cast.id)}
+                          className="w-4 h-4 rounded accent-[#dfbd69] shrink-0"
+                        />
+                        <span className="text-[13px] text-[#f4f1ea] flex-1 truncate">
+                          {cast.stage_name}
+                        </span>
+                        {isScheduled && (
+                          <span className="text-[9px] text-[#8a8478] bg-white/5 px-1.5 py-0.5 rounded-full shrink-0">
+                            出勤予定
+                          </span>
+                        )}
+                      </label>
+                    )
+                  })}
+                </div>
+
+                <p className="text-[10px] text-[#5a5650] mt-1.5">{selectedIds.size}名選択中</p>
+              </div>
+
+              {/* Message */}
+              <div>
+                <p className="text-[11px] font-bold text-[#8a8478] uppercase tracking-wider mb-2">
+                  メッセージ
+                </p>
+                <textarea
+                  value={message}
+                  onChange={e => setMessage(e.target.value)}
+                  rows={4}
+                  className="w-full bg-black/40 border border-white/10 rounded-[8px] px-3 py-2.5 text-[12px] text-[#f4f1ea] resize-none focus:outline-none focus:border-[#dfbd6940] transition-colors leading-relaxed"
+                />
+                <p className="text-[10px] text-[#5a5650] mt-1">
+                  ※ LINE送信はしません。ログ記録後にコピーして手動送信してください。
+                </p>
+              </div>
+
+              {/* Submit */}
+              <button
+                type="button"
+                onClick={handleSubmit}
+                disabled={isPending || selectedIds.size === 0}
+                className="w-full flex items-center justify-center gap-2 py-3 bg-[linear-gradient(90deg,rgba(223,189,105,0.12)_0%,rgba(146,111,52,0.12)_100%)] border border-[#dfbd6940] text-[#dfbd69] text-[12px] font-bold rounded-[8px] hover:bg-[linear-gradient(90deg,rgba(223,189,105,0.22)_0%,rgba(146,111,52,0.22)_100%)] transition-all disabled:opacity-40 disabled:cursor-not-allowed min-h-[44px]"
+              >
+                <Send size={13} />
+                {isPending ? '記録中...' : `${selectedIds.size}名に依頼ログを記録する`}
+              </button>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/components/features/admin/ShiftManager.tsx
+++ b/components/features/admin/ShiftManager.tsx
@@ -5,6 +5,8 @@ import { saveSchedules } from '@/lib/actions/schedules'
 import { toast } from 'sonner'
 import { ChevronLeft, ChevronRight, Clock, Save, Loader2, Check, CalendarDays, List } from 'lucide-react'
 import { useRouter } from 'next/navigation'
+import { type DailyStaffing } from '@/lib/config/shift-staffing'
+import { AttendanceRequestModal } from '@/components/features/admin/AttendanceRequestModal'
 
 const TIME_OPTIONS = [
   '19:00', '19:30', '20:00', '20:30', '21:00', '21:30',
@@ -20,10 +22,10 @@ type ShiftKey = string // `${castId}_${date}`
 type ShiftMap = Map<ShiftKey, { start_time: string; end_time: string }>
 
 export function ShiftManager({ initialData, viewType = 'week' }: {
-  initialData: { casts: CastData[]; shifts: ShiftData[]; dates: string[] }
+  initialData: { casts: CastData[]; shifts: ShiftData[]; dates: string[]; dailyStaffing?: Record<string, DailyStaffing> }
   viewType?: 'week' | 'month'
 }) {
-  const { casts, shifts, dates } = initialData
+  const { casts, shifts, dates, dailyStaffing } = initialData
   const [isPending, startTransition] = useTransition()
   const router = useRouter()
 
@@ -41,6 +43,7 @@ export function ShiftManager({ initialData, viewType = 'week' }: {
   })
 
   const [editingCell, setEditingCell] = useState<{ castId: string; date: string } | null>(null)
+  const [selectedRequestDate, setSelectedRequestDate] = useState<string | null>(null)
 
   const toggleShift = useCallback((castId: string, date: string) => {
     setShiftMap(prev => {
@@ -182,12 +185,35 @@ export function ShiftManager({ initialData, viewType = 'week' }: {
                 const d = new Date(date)
                 const isSat = d.getDay() === 6
                 const isSun = d.getDay() === 0
+                const staffing = dailyStaffing?.[date]
+                const staffingLevel = staffing?.level
+                const staffingCount = staffing?.scheduledWorkingCount
                 return (
                   <th key={date} className="px-2 py-3 text-center bg-white/5 border-l border-white/5">
                     <p className={`text-xs font-bold tracking-widest ${isSat ? 'text-blue-400' : isSun ? 'text-red-400' : 'text-[#8a8478]'}`}>
                       {DAYS_SHORT[i]}
                     </p>
                     <p className="text-sm font-serif text-[#f4f1ea] mt-0.5">{d.getDate()}</p>
+                    {staffing && (
+                      <div className="mt-1 flex flex-col items-center gap-0.5">
+                        <span className={`text-[9px] font-bold px-1.5 py-0.5 rounded-full ${
+                          staffingLevel === 'critical' ? 'text-[#e08080] bg-[#e0808015]' :
+                          staffingLevel === 'low' ? 'text-[#dfbd69] bg-[#dfbd6915]' :
+                          'text-[#72b894] bg-[#72b89415]'
+                        }`}>
+                          {staffingCount}名
+                        </span>
+                        {(staffingLevel === 'low' || staffingLevel === 'critical') && (
+                          <button
+                            type="button"
+                            onClick={() => setSelectedRequestDate(date)}
+                            className="text-[9px] font-bold text-[#dfbd69] border border-[#dfbd6940] rounded-full px-1.5 py-0.5 hover:bg-[#dfbd6915] transition-colors"
+                          >
+                            依頼
+                          </button>
+                        )}
+                      </div>
+                    )}
                   </th>
                 )
               })}
@@ -280,6 +306,47 @@ export function ShiftManager({ initialData, viewType = 'week' }: {
         </table>
       </div>
 
+      {/* Mobile staffing summary */}
+      {dailyStaffing && (
+        <div className="md:hidden overflow-x-auto pb-1">
+          <div className="flex gap-1.5 min-w-max py-1">
+            {dates.map(date => {
+              const staffing = dailyStaffing[date]
+              if (!staffing) return null
+              const { scheduledWorkingCount: count, level } = staffing
+              const d = new Date(date)
+              const dDay = d.getDay() === 0 ? 6 : d.getDay() - 1
+              const dLabel = DAYS_SHORT[dDay] ?? ''
+              return (
+                <div
+                  key={date}
+                  className={`flex flex-col items-center gap-0.5 px-2 py-1.5 rounded-[8px] border min-w-[44px] ${
+                    level === 'critical' ? 'border-[#e08080]/40 bg-[#e0808010]' :
+                    level === 'low' ? 'border-[#dfbd69]/40 bg-[#dfbd6910]' :
+                    'border-white/10 bg-white/5'
+                  }`}
+                >
+                  <span className="text-[9px] text-[#8a8478]">{d.getDate()}({dLabel})</span>
+                  <span className={`text-[11px] font-bold ${
+                    level === 'critical' ? 'text-[#e08080]' :
+                    level === 'low' ? 'text-[#dfbd69]' : 'text-[#72b894]'
+                  }`}>{count}</span>
+                  {(level === 'low' || level === 'critical') && (
+                    <button
+                      type="button"
+                      onClick={() => setSelectedRequestDate(date)}
+                      className="text-[8px] font-bold text-[#dfbd69] border border-[#dfbd6940] rounded-full px-1.5 py-0.5 hover:bg-[#dfbd6915] transition-colors"
+                    >
+                      依頼
+                    </button>
+                  )}
+                </div>
+              )
+            })}
+          </div>
+        </div>
+      )}
+
       {/* Mobile Card UI */}
       <div className="md:hidden space-y-4">
         {(!casts || casts.length === 0) ? (
@@ -371,6 +438,17 @@ export function ShiftManager({ initialData, viewType = 'week' }: {
           );
         })}
       </div>
+
+      {/* Attendance Request Modal */}
+      {selectedRequestDate && (
+        <AttendanceRequestModal
+          date={selectedRequestDate}
+          scheduledCount={dailyStaffing?.[selectedRequestDate]?.scheduledWorkingCount ?? 0}
+          allCasts={casts.map(c => ({ id: c.id, stage_name: c.stage_name }))}
+          scheduledCastIds={new Set(casts.filter(c => shiftMap.has(`${c.id}_${selectedRequestDate}`)).map(c => c.id))}
+          onClose={() => setSelectedRequestDate(null)}
+        />
+      )}
 
       {/* Summary Footer */}
       <div className="flex items-center justify-between text-xs text-[#8a8478] pt-2">

--- a/components/features/admin/dashboard/DashboardTodayShifts.tsx
+++ b/components/features/admin/dashboard/DashboardTodayShifts.tsx
@@ -1,155 +1,85 @@
-import { getDashboardCastShifts } from '@/lib/actions/dashboard';
-import Link from 'next/link';
-import { DashboardEmptyState } from './DashboardEmptyState';
-import { ChevronRight, Users } from 'lucide-react';
-
-const STATUS_CONFIG = {
-  confirmed: {
-    label: '確定',
-    bg: 'bg-[#50a06414]',
-    border: 'border-[#50a0642e]',
-    textColor: 'text-[#72b894]',
-    dot: 'bg-[#72b894]',
-  },
-  late: {
-    label: '予定遅刻',
-    bg: 'bg-[#c8823214]',
-    border: 'border-[#c882322e]',
-    textColor: 'text-[#c8884d]',
-    dot: 'bg-[#c8884d]',
-  },
-  trial: {
-    label: '体験入店',
-    bg: 'bg-[#dfbd6914]',
-    border: 'border-[#dfbd692e]',
-    textColor: 'text-[#dfbd69]',
-    dot: 'bg-[#dfbd69]',
-  },
-  pending: {
-    label: '確認待ち',
-    bg: 'bg-[#8a847814]',
-    border: 'border-[#8a84782e]',
-    textColor: 'text-[#8a8478]',
-    dot: 'bg-[#8a8478]',
-  },
-} as const;
+import { getDashboardCastShifts } from '@/lib/actions/dashboard'
+import Link from 'next/link'
+import { DashboardEmptyState } from './DashboardEmptyState'
+import { DashboardTodayShiftsRow } from './DashboardTodayShiftsRow'
+import { ChevronRight, Users } from 'lucide-react'
 
 export async function DashboardTodayShifts() {
-  const casts = await getDashboardCastShifts();
+  const casts = await getDashboardCastShifts()
 
-  const confirmedCount = casts.filter((c) => c.status === 'confirmed').length;
-  const lateCount = casts.filter((c) => c.status === 'late').length;
-  const trialCount = casts.filter((c) => c.status === 'trial').length;
+  const workingCount = casts.filter(
+    (c) => c.status === 'working' || c.status === 'confirmed'
+  ).length
+  const absentCount = casts.filter((c) => c.status === 'absent').length
+  const lateCount = casts.filter((c) => c.status === 'late').length
+  const trialCount = casts.filter((c) => c.status === 'trial').length
+
+  const summaryParts: string[] = [`出勤 ${workingCount}名`]
+  if (absentCount > 0) summaryParts.push(`欠勤 ${absentCount}名`)
+  if (lateCount > 0) summaryParts.push(`遅刻 ${lateCount}名`)
+  if (trialCount > 0) summaryParts.push(`体験 ${trialCount}名`)
 
   return (
     <div className="flex flex-col rounded-[18px] font-sans h-full card-premium-skin">
       <div className="card-premium-skin__surface flex flex-col flex-1 overflow-hidden rounded-[18px]">
-      {/* Header */}
-      <div className="flex items-center justify-between px-6 h-[56px] border-b border-[#ffffff0f] shrink-0">
-        <div className="flex items-center gap-3">
-          <div className="w-[33px] h-[33px] flex items-center justify-center bg-[#dfbd691a] rounded-[7px] shrink-0">
-            <Users size={15} className="text-[#dfbd69]" strokeWidth={2.5} />
+        {/* Header */}
+        <div className="flex items-center justify-between px-6 h-[56px] border-b border-[#ffffff0f] shrink-0">
+          <div className="flex items-center gap-3">
+            <div className="w-[33px] h-[33px] flex items-center justify-center bg-[#dfbd691a] rounded-[7px] shrink-0">
+              <Users size={15} className="text-[#dfbd69]" strokeWidth={2.5} />
+            </div>
+            <div className="flex flex-col">
+              <p className="text-[13px] font-bold text-[#f4f1ea] tracking-[-0.08px] leading-tight">
+                本日の出勤キャスト
+              </p>
+              <p className="text-[11px] text-[#8a8478] tracking-[0.06px] leading-tight">
+                {summaryParts.join(' / ')}
+              </p>
+            </div>
           </div>
-          <div className="flex flex-col">
-            <p className="text-[13px] font-bold text-[#f4f1ea] tracking-[-0.08px] leading-tight">本日の出勤キャスト</p>
-            <p className="text-[11px] text-[#8a8478] tracking-[0.06px] leading-tight">
-              確定 {confirmedCount}名
-              {lateCount > 0 && ` / 遅刻 ${lateCount}名`}
-              {trialCount > 0 && ` / 体験 ${trialCount}名`}
-            </p>
-          </div>
+          <Link
+            href="/admin/today"
+            className="flex items-center gap-2 px-5 h-[40px] rounded-[10px] bg-white/4 border border-gold/40 text-[12px] font-bold text-[#dfbd69] hover:bg-[#dfbd6910] transition-all"
+          >
+            <span>詳細を表示</span>
+            <ChevronRight size={14} />
+          </Link>
         </div>
-        <Link
-          href="/admin/today"
-          className="flex items-center gap-2 px-5 h-[40px] rounded-[10px] bg-white/4 border border-gold/40 text-[12px] font-bold text-[#dfbd69] hover:bg-[#dfbd6910] transition-all"
-        >
-          <span>詳細を表示</span>
-          <ChevronRight size={14} />
-        </Link>
-      </div>
 
-      {/* Table */}
-      {casts.length === 0 ? (
-        <div className="flex-1 p-5">
-          <DashboardEmptyState className="min-h-[200px] h-full" />
-        </div>
-      ) : (
-      <div className="flex-1 overflow-x-auto custom-scrollbar">
-        <div className="min-w-[900px]">
-          {/* Table Header Row */}
-          <div className="flex items-center h-[42px] border-t border-b border-[#ffffff0a] px-6 bg-white/1">
-            <div className="w-[240px] text-[9px] font-bold tracking-[1px] text-[#5a5650] uppercase">CAST NAME</div>
-            <div className="w-section text-[9px] font-bold tracking-[1px] text-[#5a5650] uppercase px-4">SHIFT TIME</div>
-            <div className="w-[120px] text-[9px] font-bold tracking-[1px] text-[#5a5650] uppercase text-center">STATUS</div>
-            <div className="flex-1 text-[9px] font-bold tracking-[1px] text-[#5a5650] uppercase px-4">MEMO / TAGS</div>
+        {/* Table */}
+        {casts.length === 0 ? (
+          <div className="flex-1 p-5">
+            <DashboardEmptyState className="min-h-[200px] h-full" />
           </div>
+        ) : (
+          <div className="flex-1 overflow-x-auto custom-scrollbar">
+            <div className="min-w-[960px]">
+              {/* Table Header Row */}
+              <div className="flex items-center h-[42px] border-t border-b border-[#ffffff0a] px-6 bg-white/1">
+                <div className="w-[240px] text-[9px] font-bold tracking-[1px] text-[#5a5650] uppercase">
+                  CAST NAME
+                </div>
+                <div className="w-section text-[9px] font-bold tracking-[1px] text-[#5a5650] uppercase px-6">
+                  SHIFT TIME
+                </div>
+                <div className="w-[220px] text-[9px] font-bold tracking-[1px] text-[#5a5650] uppercase">
+                  ATTENDANCE
+                </div>
+                <div className="flex-1 text-[9px] font-bold tracking-[1px] text-[#5a5650] uppercase px-4">
+                  MEMO / TAGS
+                </div>
+              </div>
 
-          {/* Table Body */}
-          <div className="divide-y divide-[#ffffff0a]">
-            {casts.map((cast) => {
-                const cfg = STATUS_CONFIG[cast.status] || STATUS_CONFIG.pending;
-                return (
-                  <div
-                    key={cast.castId}
-                    className="flex items-center min-h-[52px] hover:bg-white/2 transition-colors px-6"
-                  >
-                    <div className="w-[240px] flex items-center gap-3 shrink-0">
-                      <div className="w-10 h-10 rounded-full bg-[#1c1d22] border border-[#ffffff0a] flex items-center justify-center shrink-0 overflow-hidden relative shadow-2xl">
-                        {cast.avatarUrl ? (
-                           <img 
-                             src={cast.avatarUrl} 
-                             alt={cast.castName} 
-                             className="w-full h-full object-cover" 
-                             referrerPolicy="no-referrer"
-                           />
-                        ) : (
-                          <span className="text-[11px] font-bold text-[#5a5650]">{cast.initial}</span>
-                        )}
-                        <div className="absolute inset-0 ring-1 ring-inset ring-white/10 rounded-full" />
-                      </div>
-                      <span className="text-[14px] font-bold text-[#f4f1ea] tracking-tight">{cast.castName}</span>
-                    </div>
-                    
-                    {/* Time */}
-                    <div className="w-section px-6">
-                      <div className="inline-flex items-center gap-2 text-[14px] font-bold text-gold font-sans bg-gold/5 px-3 py-1.5 rounded-[6px] border border-gold/10">
-                        <span>{cast.startTime}</span>
-                        <span className="text-[#5a5650] font-normal opacity-50">—</span>
-                        <span className="text-[#8a8478] font-medium">{cast.endTime || '—'}</span>
-                      </div>
-                    </div>
-
-                    {/* Status Badge */}
-                    <div className="w-[140px] flex justify-center">
-                      <div className={`flex items-center gap-2 px-4 py-1.5 ${cfg.bg} rounded-full border ${cfg.border} min-w-[90px] justify-center shadow-lg shadow-black/20`}>
-                        <div className={`w-[6px] h-[6px] rounded-full ${cfg.dot}`} />
-                        <span className={`font-sans text-[10px] font-bold tracking-[0.117px] leading-[14px] uppercase ${cfg.textColor}`}>{cfg.label}</span>
-                      </div>
-                    </div>
-
-                    {/* Tags */}
-                    <div className="flex-1 px-4 flex flex-wrap gap-2">
-                      {cast.tags.length > 0 ? (
-                        cast.tags.map((tag, i) => (
-                          <span
-                             key={i}
-                             className="px-2.5 py-1 bg-white/3 border border-white/5 rounded-[6px] font-sans text-[10px] font-semibold text-[#8a8478] tracking-[0.117px] leading-[14px] hover:text-[#dfbd69] transition-colors"
-                          >
-                            {tag}
-                          </span>
-                        ))
-                      ) : (
-                        <span className="text-[11px] text-[#5a5650] tracking-widest opacity-40">—</span>
-                      )}
-                    </div>
-                  </div>
-                );
-              })}
+              {/* Table Body */}
+              <div className="divide-y divide-[#ffffff0a]">
+                {casts.map((cast) => (
+                  <DashboardTodayShiftsRow key={cast.castId} cast={cast} />
+                ))}
+              </div>
+            </div>
           </div>
-        </div>
-      </div>
-      )}
+        )}
       </div>
     </div>
-  );
+  )
 }

--- a/components/features/admin/dashboard/DashboardTodayShiftsRow.tsx
+++ b/components/features/admin/dashboard/DashboardTodayShiftsRow.tsx
@@ -1,0 +1,196 @@
+'use client'
+
+import { useOptimistic, useTransition } from 'react'
+import { updateDailyCastAttendance } from '@/lib/actions/today'
+import type { DashboardCastShift, ManualAttendanceStatus } from '@/lib/actions/dashboard'
+
+// ──────────────────────────────────────────────────────
+// Status badge config — includes manual override states
+// ──────────────────────────────────────────────────────
+const STATUS_CONFIG = {
+  confirmed: {
+    label: '確定',
+    bg: 'bg-[#50a06414]',
+    border: 'border-[#50a0642e]',
+    textColor: 'text-[#72b894]',
+    dot: 'bg-[#72b894]',
+  },
+  working: {
+    label: '出勤',
+    bg: 'bg-[#50a06414]',
+    border: 'border-[#50a0642e]',
+    textColor: 'text-[#72b894]',
+    dot: 'bg-[#72b894]',
+  },
+  late: {
+    label: '予定遅刻',
+    bg: 'bg-[#c8823214]',
+    border: 'border-[#c882322e]',
+    textColor: 'text-[#c8884d]',
+    dot: 'bg-[#c8884d]',
+  },
+  trial: {
+    label: '体験入店',
+    bg: 'bg-[#dfbd6914]',
+    border: 'border-[#dfbd692e]',
+    textColor: 'text-[#dfbd69]',
+    dot: 'bg-[#dfbd69]',
+  },
+  absent: {
+    label: '欠勤',
+    bg: 'bg-[#e05c5c14]',
+    border: 'border-[#e05c5c2e]',
+    textColor: 'text-[#e08080]',
+    dot: 'bg-[#e08080]',
+  },
+  pending: {
+    label: '確認待ち',
+    bg: 'bg-[#8a847814]',
+    border: 'border-[#8a84782e]',
+    textColor: 'text-[#8a8478]',
+    dot: 'bg-[#8a8478]',
+  },
+} as const
+
+const SOURCE_LABEL: Record<string, string> = {
+  manual: '手動変更',
+  checkin: '今日の回答',
+  shift: 'シフト申請',
+  none: '',
+}
+
+// ──────────────────────────────────────────────────────
+// Row component
+// ──────────────────────────────────────────────────────
+export function DashboardTodayShiftsRow({ cast }: { cast: DashboardCastShift }) {
+  const [isPending, startTransition] = useTransition()
+  const [optimisticManual, setOptimisticManual] = useOptimistic<ManualAttendanceStatus>(
+    cast.manualStatus
+  )
+
+  const isTrial = cast.castId.startsWith('trial-')
+
+  function handleOverride(status: ManualAttendanceStatus): void {
+    if (isTrial) return
+    setOptimisticManual(status)
+    startTransition(async () => {
+      await updateDailyCastAttendance({ castId: cast.castId, status })
+    })
+  }
+
+  const cfg = STATUS_CONFIG[cast.status] ?? STATUS_CONFIG.pending
+  const sourceLabel = SOURCE_LABEL[cast.finalStatusSource] ?? ''
+
+  return (
+    <div
+      className={`flex items-center min-h-[60px] hover:bg-white/2 transition-colors px-6 ${isPending ? 'opacity-70' : ''}`}
+    >
+      {/* Cast name */}
+      <div className="w-[240px] flex items-center gap-3 shrink-0">
+        <div className="w-10 h-10 rounded-full bg-[#1c1d22] border border-[#ffffff0a] flex items-center justify-center shrink-0 overflow-hidden relative shadow-2xl">
+          {cast.avatarUrl ? (
+            <img
+              src={cast.avatarUrl}
+              alt={cast.castName}
+              className="w-full h-full object-cover"
+              referrerPolicy="no-referrer"
+            />
+          ) : (
+            <span className="text-[11px] font-bold text-[#5a5650]">{cast.initial}</span>
+          )}
+          <div className="absolute inset-0 ring-1 ring-inset ring-white/10 rounded-full" />
+        </div>
+        <span className="text-[14px] font-bold text-[#f4f1ea] tracking-tight">{cast.castName}</span>
+      </div>
+
+      {/* Shift time */}
+      <div className="w-section px-6 shrink-0">
+        <div className="inline-flex items-center gap-2 text-[14px] font-bold text-gold font-sans bg-gold/5 px-3 py-1.5 rounded-[6px] border border-gold/10">
+          <span>{cast.startTime}</span>
+          <span className="text-[#5a5650] font-normal opacity-50">—</span>
+          <span className="text-[#8a8478] font-medium">{cast.endTime || '—'}</span>
+        </div>
+      </div>
+
+      {/* Attendance status + manual override controls */}
+      <div className="w-[220px] shrink-0 flex flex-col gap-2 py-2">
+        {/* Status badge + source */}
+        <div className="flex items-center gap-2 flex-wrap">
+          <div
+            className={`flex items-center gap-1.5 px-3 py-1 ${cfg.bg} rounded-full border ${cfg.border} shadow-sm`}
+          >
+            <div className={`w-[5px] h-[5px] rounded-full ${cfg.dot}`} />
+            <span className={`font-sans text-[10px] font-bold tracking-[0.1px] leading-[14px] ${cfg.textColor}`}>
+              {cfg.label}
+            </span>
+          </div>
+          {sourceLabel && (
+            <span className="text-[9px] text-[#5a5650] tracking-wide font-medium">{sourceLabel}</span>
+          )}
+        </div>
+
+        {/* Override buttons — hidden for trial entries */}
+        {!isTrial && (
+          <div className="flex items-center gap-1">
+            <button
+              type="button"
+              onClick={() => handleOverride('working')}
+              disabled={isPending}
+              aria-pressed={optimisticManual === 'working'}
+              className={`text-[10px] font-bold px-2.5 py-1.5 rounded-[5px] border transition-all min-h-[28px] min-w-[44px] ${
+                optimisticManual === 'working'
+                  ? 'bg-[#72b89420] border-[#72b89450] text-[#72b894]'
+                  : 'bg-white/3 border-white/8 text-[#5a5650] hover:text-[#72b894] hover:border-[#72b89430] hover:bg-[#72b89410]'
+              } disabled:cursor-not-allowed`}
+            >
+              出勤
+            </button>
+            <button
+              type="button"
+              onClick={() => handleOverride('absent')}
+              disabled={isPending}
+              aria-pressed={optimisticManual === 'absent'}
+              className={`text-[10px] font-bold px-2.5 py-1.5 rounded-[5px] border transition-all min-h-[28px] min-w-[44px] ${
+                optimisticManual === 'absent'
+                  ? 'bg-[#e0808020] border-[#e0808050] text-[#e08080]'
+                  : 'bg-white/3 border-white/8 text-[#5a5650] hover:text-[#e08080] hover:border-[#e0808030] hover:bg-[#e0808010]'
+              } disabled:cursor-not-allowed`}
+            >
+              欠勤
+            </button>
+            <button
+              type="button"
+              onClick={() => handleOverride('undecided')}
+              disabled={isPending}
+              aria-pressed={optimisticManual === 'undecided'}
+              title="手動変更をリセット"
+              className={`text-[10px] font-bold px-2.5 py-1.5 rounded-[5px] border transition-all min-h-[28px] min-w-[28px] ${
+                optimisticManual === 'undecided'
+                  ? 'bg-white/5 border-white/15 text-[#8a8478]'
+                  : 'bg-white/2 border-white/5 text-[#3a3830] hover:text-[#8a8478] hover:border-white/15'
+              } disabled:cursor-not-allowed`}
+            >
+              —
+            </button>
+          </div>
+        )}
+      </div>
+
+      {/* Tags */}
+      <div className="flex-1 px-4 flex flex-wrap gap-2 items-center">
+        {cast.tags.length > 0 ? (
+          cast.tags.map((tag, i) => (
+            <span
+              key={i}
+              className="px-2.5 py-1 bg-white/3 border border-white/5 rounded-[6px] font-sans text-[10px] font-semibold text-[#8a8478] tracking-[0.117px] leading-[14px] hover:text-[#dfbd69] transition-colors"
+            >
+              {tag}
+            </span>
+          ))
+        ) : (
+          <span className="text-[11px] text-[#5a5650] tracking-widest opacity-40">—</span>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/lib/actions/dashboard.ts
+++ b/lib/actions/dashboard.ts
@@ -45,16 +45,22 @@ export type DashboardReservation = {
   reservationType: string;
 };
 
+export type ManualAttendanceStatus = 'working' | 'absent' | 'undecided'
+export type FinalStatusSource = 'manual' | 'checkin' | 'shift' | 'none'
+
 export type DashboardCastShift = {
-  castId: string;
-  castName: string;
-  initial: string;
-  startTime: string;
-  endTime?: string;
-  status: 'confirmed' | 'late' | 'trial' | 'pending';
-  tags: string[];
-  avatarUrl?: string;
-};
+  castId: string
+  castName: string
+  initial: string
+  startTime: string
+  endTime?: string
+  status: 'confirmed' | 'late' | 'trial' | 'pending' | 'working' | 'absent'
+  tags: string[]
+  avatarUrl?: string
+  manualStatus: ManualAttendanceStatus
+  manualNote: string | null
+  finalStatusSource: FinalStatusSource
+}
 
 export type DashboardCastRanking = {
   rank: number;
@@ -290,14 +296,15 @@ export async function getDashboardReservations(): Promise<DashboardReservation[]
 // 本日の出勤キャスト（Figmaデザイン版）
 // ─────────────────────────────────────────────
 export async function getDashboardCastShifts(): Promise<DashboardCastShift[]> {
-  const supabase = createServiceClient();
-  const today = getJstDateString();
+  const supabase = createServiceClient()
+  const today = getJstDateString()
 
   const [
     { data: shiftsRaw },
     { data: checkinsRaw },
     { data: trials },
     { data: postsRaw },
+    { data: manualRaw },
   ] = await Promise.all([
     supabase.from('shift_submissions').select('cast_id, shifts_data, casts(stage_name, profile_image_url)').eq('status', 'approved'),
     supabase.from('daily_checkins').select('cast_id, is_absent, has_change, change_note').eq('checkin_date', today),
@@ -307,38 +314,62 @@ export async function getDashboardCastShifts(): Promise<DashboardCastShift[]> {
       .select('cast_id, created_at')
       .gte('created_at', new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString())
       .eq('status', 'approved'),
-  ]);
+    supabase
+      .from('daily_cast_attendance')
+      .select('cast_id, status, note')
+      .eq('business_date', today),
+  ])
 
-  const checkinMap = new Map((checkinsRaw || []).map(c => [c.cast_id, c]));
-  const recentPostCastIds = new Set((postsRaw || []).map(p => p.cast_id));
+  const checkinMap = new Map((checkinsRaw || []).map(c => [c.cast_id, c]))
+  const recentPostCastIds = new Set((postsRaw || []).map(p => p.cast_id))
+  const manualMap = new Map(
+    (manualRaw || []).map(m => [m.cast_id, { status: m.status as ManualAttendanceStatus, note: m.note as string | null }])
+  )
 
-  const results: DashboardCastShift[] = [];
+  const results: DashboardCastShift[] = []
 
-  // 承認済シフトから本日出勤キャストを抽出
+  // 承認済シフトから本日出勤キャストを抽出（欠勤フィルタなし — manual override で表示制御）
   if (shiftsRaw) {
     for (const row of shiftsRaw) {
-      const d = row.shifts_data as Record<string, { type: string; start: string; end: string }>;
-      if (d[today]?.type !== 'work') continue;
+      const d = row.shifts_data as Record<string, { type: string; start: string; end: string }>
+      if (d[today]?.type !== 'work') continue
 
-      // Supabaseの結合データからキャスト情報を取得
-      const castRaw = row.casts as unknown as { stage_name: string; profile_image_url?: string } | null;
-      const castName = castRaw?.stage_name ?? '不明';
-      const avatarUrl = castRaw?.profile_image_url ?? undefined;
-      
-      const checkin = checkinMap.get(row.cast_id);
-      const isAbsent = checkin?.is_absent ?? false;
-      const hasChange = checkin?.has_change ?? false;
+      const castRaw = row.casts as unknown as { stage_name: string; profile_image_url?: string } | null
+      const castName = castRaw?.stage_name ?? '不明'
+      const avatarUrl = castRaw?.profile_image_url ?? undefined
 
-      if (isAbsent) continue;
+      const manual = manualMap.get(row.cast_id)
+      const checkin = checkinMap.get(row.cast_id)
 
-      let status: DashboardCastShift['status'] = 'pending';
-      if (checkin && !isAbsent) {
-        status = hasChange ? 'late' : 'confirmed';
+      // 最終出勤状態の優先順位:
+      //   1. manual working/absent (firm override)
+      //   2. daily_checkins (cast self-report)
+      //   3. shift exists → pending
+      //   4. undecided
+      let status: DashboardCastShift['status']
+      let finalStatusSource: FinalStatusSource
+
+      if (manual && (manual.status === 'working' || manual.status === 'absent')) {
+        status = manual.status
+        finalStatusSource = 'manual'
+      } else if (checkin) {
+        if (checkin.is_absent) {
+          status = 'absent'
+        } else if (checkin.has_change) {
+          status = 'late'
+        } else {
+          status = 'confirmed'
+        }
+        finalStatusSource = 'checkin'
+      } else {
+        status = 'pending'
+        finalStatusSource = 'shift'
       }
 
-      const tags: string[] = [];
-      if (recentPostCastIds.has(row.cast_id)) tags.push('ブログ更新済');
-      if (status === 'late') tags.push('確認必要');
+      const tags: string[] = []
+      if (recentPostCastIds.has(row.cast_id)) tags.push('ブログ更新済')
+      if (status === 'late') tags.push('確認必要')
+      if (status === 'absent') tags.push('欠勤')
 
       results.push({
         castId: row.cast_id,
@@ -349,11 +380,14 @@ export async function getDashboardCastShifts(): Promise<DashboardCastShift[]> {
         status,
         tags,
         avatarUrl,
-      });
+        manualStatus: manual?.status ?? 'undecided',
+        manualNote: manual?.note ?? null,
+        finalStatusSource,
+      })
     }
   }
 
-  // 体験入店
+  // 体験入店（manual override 対象外）
   for (const trial of (trials || [])) {
     results.push({
       castId: `trial-${trial.id}`,
@@ -362,11 +396,14 @@ export async function getDashboardCastShifts(): Promise<DashboardCastShift[]> {
       startTime: trial.start_time?.substring(0, 5) ?? '20:00',
       status: 'trial',
       tags: ['初回体入'],
-    });
+      manualStatus: 'undecided',
+      manualNote: null,
+      finalStatusSource: 'none',
+    })
   }
 
-  results.sort((a, b) => a.startTime.localeCompare(b.startTime));
-  return results;
+  results.sort((a, b) => a.startTime.localeCompare(b.startTime))
+  return results
 }
 
 // ─────────────────────────────────────────────

--- a/lib/actions/notifications.ts
+++ b/lib/actions/notifications.ts
@@ -1,0 +1,74 @@
+'use server'
+
+import { createClient } from '@/lib/supabase/server'
+import { revalidatePath } from 'next/cache'
+import { getAppRole, isAdminLoginRole } from '@/lib/auth/admin-roles'
+
+export type SendShiftRequestResult = {
+  success: boolean
+  requestedCount: number
+  skippedCount: number
+  copyMessage: string
+  error?: string
+}
+
+function buildDefaultMessage(businessDate: string): string {
+  const [, month, day] = businessDate.split('-')
+  return `${parseInt(month)}月${parseInt(day)}日の出勤キャストが不足しているため、出勤可能な方を探しています。\n出勤可能な場合は、アニモ公式LINEへ返信をお願いします。`
+}
+
+// 管理者: 出勤依頼ログを記録し、コピー用メッセージを返す。
+// LINE APIへの直接送信は行わない。channel='internal', status='pending' で作成する。
+// 同一 (business_date, cast_id, channel) で pending/sent が既にある場合は重複を無視する。
+export async function sendShiftRequestNotification(input: {
+  businessDate: string
+  castIds: string[]
+  message?: string
+}): Promise<SendShiftRequestResult> {
+  const supabase = await createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) return { success: false, requestedCount: 0, skippedCount: 0, copyMessage: '', error: 'Unauthorized' }
+
+  const role = await getAppRole(supabase, user.id)
+  if (!isAdminLoginRole(role)) return { success: false, requestedCount: 0, skippedCount: 0, copyMessage: '', error: 'Forbidden' }
+
+  if (!input.castIds || input.castIds.length === 0) {
+    return { success: false, requestedCount: 0, skippedCount: 0, copyMessage: '', error: '対象キャストを選択してください' }
+  }
+
+  const msg = (input.message?.trim()) || buildDefaultMessage(input.businessDate)
+
+  const records = input.castIds.map(castId => ({
+    business_date: input.businessDate,
+    cast_id: castId,
+    message: msg,
+    status: 'pending',
+    channel: 'internal',
+    sent_by: user.id,
+  }))
+
+  // ignoreDuplicates=true → ON CONFLICT DO NOTHING
+  // 部分ユニークインデックス (business_date, cast_id, channel) WHERE status IN ('pending','sent') により
+  // 既存の pending/sent レコードがある場合はスキップされる。
+  const { data: inserted, error } = await supabase
+    .from('cast_shift_request_notifications')
+    .upsert(records, { ignoreDuplicates: true })
+    .select('id')
+
+  if (error) {
+    console.error('[sendShiftRequestNotification]', error)
+    return { success: false, requestedCount: 0, skippedCount: input.castIds.length, copyMessage: '', error: error.message }
+  }
+
+  const requestedCount = inserted?.length ?? 0
+  const skippedCount = input.castIds.length - requestedCount
+
+  revalidatePath('/admin/shifts')
+
+  return {
+    success: true,
+    requestedCount,
+    skippedCount,
+    copyMessage: msg,
+  }
+}

--- a/lib/actions/schedules.ts
+++ b/lib/actions/schedules.ts
@@ -2,6 +2,7 @@
 
 import { createClient } from '@/lib/supabase/server'
 import { revalidatePath } from 'next/cache'
+import { getStaffingLevel, type DailyStaffing } from '@/lib/config/shift-staffing'
 
 function getWeekDates(startDate = new Date()): string[] {
   const dates: string[] = []
@@ -50,7 +51,8 @@ export async function getWeeklySchedules(targetDate = new Date()) {
     .lte('work_date', dates[6])
   if (schedulesError) throw new Error(schedulesError.message)
 
-  return { casts, schedules, dates }
+  const dailyStaffing = computeDailyStaffing(dates, schedules ?? [])
+  return { casts, schedules, dates, dailyStaffing }
 }
 
 export async function getMonthlySchedules(targetDate = new Date()) {
@@ -73,7 +75,27 @@ export async function getMonthlySchedules(targetDate = new Date()) {
     .lte('work_date', dates[dates.length - 1])
   if (schedulesError) throw new Error(schedulesError.message)
 
-  return { casts, schedules, dates }
+  const dailyStaffing = computeDailyStaffing(dates, schedules ?? [])
+  return { casts, schedules, dates, dailyStaffing }
+}
+
+// Compute scheduledWorkingCount and staffing level per date from already-fetched schedule rows.
+// Uses distinct cast_id per date to avoid double-counting any duplicate rows.
+function computeDailyStaffing(
+  dates: string[],
+  schedules: { cast_id: string; work_date?: string; date?: string; [key: string]: unknown }[]
+): Record<string, DailyStaffing> {
+  const result: Record<string, DailyStaffing> = {}
+  for (const date of dates) {
+    const castIds = new Set<string>()
+    for (const s of schedules) {
+      const workDate = s.work_date ?? s.date ?? ''
+      if (workDate === date) castIds.add(s.cast_id)
+    }
+    const scheduledWorkingCount = castIds.size
+    result[date] = { scheduledWorkingCount, level: getStaffingLevel(scheduledWorkingCount) }
+  }
+  return result
 }
 
 export async function saveSchedules(formData: FormData) {

--- a/lib/actions/today.ts
+++ b/lib/actions/today.ts
@@ -8,6 +8,7 @@ import { revalidatePath } from 'next/cache'
 import { StaffSlave } from './staffs'
 import { getAnalyticsSummary } from './analytics'
 import { isMasterAccount } from '@/lib/config/master'
+import { getAppRole, isAdminLoginRole } from '@/lib/auth/admin-roles'
 
 // 曜日の日本語変換
 const WEEKDAYS = ['日', '月', '火', '水', '木', '金', '土']
@@ -936,4 +937,48 @@ export async function getTodaySubmissionState(date: Date = new Date()) {
     isClosed: isTodaySubmissionClosed(date),
     deadlineLabel: getTodaySubmissionDeadlineLabel(),
   }
+}
+
+// ==========================================
+// 管理者: 本日のキャスト出勤手動オーバーライド
+// ==========================================
+
+export type DailyCastAttendanceStatus = 'working' | 'absent' | 'undecided'
+
+export async function updateDailyCastAttendance(input: {
+  castId: string
+  status: DailyCastAttendanceStatus
+  note?: string | null
+}): Promise<{ success: boolean; error?: string }> {
+  const supabase = await createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) return { success: false, error: 'Unauthorized' }
+
+  const role = await getAppRole(supabase, user.id)
+  if (!isAdminLoginRole(role)) return { success: false, error: 'Forbidden' }
+
+  const today = getJstDateString()
+
+  const { error } = await supabase
+    .from('daily_cast_attendance')
+    .upsert(
+      {
+        cast_id: input.castId,
+        business_date: today,
+        status: input.status,
+        source: 'manual',
+        note: input.note ?? null,
+        updated_by: user.id,
+      },
+      { onConflict: 'cast_id,business_date' }
+    )
+
+  if (error) {
+    console.error('[updateDailyCastAttendance]', error)
+    return { success: false, error: error.message }
+  }
+
+  revalidatePath('/admin/dashboard')
+  revalidatePath('/admin/today')
+  return { success: true }
 }

--- a/lib/config/shift-staffing.ts
+++ b/lib/config/shift-staffing.ts
@@ -1,0 +1,20 @@
+// Staffing threshold constants for the shift management page.
+// Adjust MINIMUM_REQUIRED_CASTS to match the actual business requirement.
+
+export const MINIMUM_REQUIRED_CASTS = 5
+
+export type StaffingLevel = 'enough' | 'low' | 'critical'
+
+// enough:   scheduledWorkingCount >= MINIMUM_REQUIRED_CASTS      (>= 5)
+// low:      scheduledWorkingCount >= MINIMUM_REQUIRED_CASTS - 2  (3 or 4)
+// critical: scheduledWorkingCount <  MINIMUM_REQUIRED_CASTS - 2  (<= 2)
+export function getStaffingLevel(scheduledWorkingCount: number): StaffingLevel {
+  if (scheduledWorkingCount >= MINIMUM_REQUIRED_CASTS) return 'enough'
+  if (scheduledWorkingCount >= MINIMUM_REQUIRED_CASTS - 2) return 'low'
+  return 'critical'
+}
+
+export type DailyStaffing = {
+  scheduledWorkingCount: number
+  level: StaffingLevel
+}

--- a/supabase/migrations/20260426000001_add_daily_cast_attendance.sql
+++ b/supabase/migrations/20260426000001_add_daily_cast_attendance.sql
@@ -1,0 +1,84 @@
+-- ==========================================
+-- 本日のキャスト出勤手動オーバーライドテーブル
+-- Phase 1: Manual Daily Cast Attendance Override
+-- ==========================================
+--
+-- 目的: 管理者・スタッフが本日のキャスト出勤状況を手動で記録・上書きするための独立テーブル。
+-- 重要: daily_checkins / shift_submissions / cast_schedules は一切変更しない。
+-- 最終出勤状態の優先順位:
+--   1. daily_cast_attendance (このテーブル, status=working|absent)
+--   2. daily_checkins (キャスト自己申告)
+--   3. shift_submissions (シフト申請)
+--   4. 未確定
+--
+-- RLSパターン: 20260319000000_add_today_dashboard.sql に準拠 (user_roles.user_id)
+-- ==========================================
+
+CREATE TABLE IF NOT EXISTS public.daily_cast_attendance (
+  id            uuid        PRIMARY KEY DEFAULT uuid_generate_v4(),
+  cast_id       uuid        NOT NULL REFERENCES public.casts(id) ON DELETE CASCADE,
+  business_date date        NOT NULL DEFAULT CURRENT_DATE,
+  status        text        NOT NULL DEFAULT 'undecided'
+                  CHECK (status IN ('working', 'absent', 'undecided')),
+  source        text        NOT NULL DEFAULT 'manual'
+                  CHECK (source IN ('manual')),
+  note          text,
+  created_by    uuid        REFERENCES auth.users(id) ON DELETE SET NULL,
+  updated_by    uuid        REFERENCES auth.users(id) ON DELETE SET NULL,
+  created_at    timestamptz NOT NULL DEFAULT now(),
+  updated_at    timestamptz NOT NULL DEFAULT now(),
+
+  CONSTRAINT daily_cast_attendance_unique UNIQUE (cast_id, business_date)
+);
+
+ALTER TABLE public.daily_cast_attendance ENABLE ROW LEVEL SECURITY;
+
+-- 管理者・スタッフ: フルアクセス（user_rolesパターン準拠）
+CREATE POLICY "Admins can manage daily_cast_attendance"
+  ON public.daily_cast_attendance TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.user_roles
+      WHERE user_roles.user_id = auth.uid()
+        AND user_roles.role IN ('owner', 'manager', 'staff')
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM public.user_roles
+      WHERE user_roles.user_id = auth.uid()
+        AND user_roles.role IN ('owner', 'manager', 'staff')
+    )
+  );
+
+-- キャスト: 自分のレコードのみ参照可（書き込み不可）
+CREATE POLICY "Casts can view own attendance override"
+  ON public.daily_cast_attendance FOR SELECT TO authenticated
+  USING (
+    cast_id IN (
+      SELECT id FROM public.casts WHERE casts.auth_user_id = auth.uid()
+    )
+  );
+
+-- インデックス
+CREATE INDEX IF NOT EXISTS idx_daily_cast_attendance_cast_id
+  ON public.daily_cast_attendance(cast_id);
+
+CREATE INDEX IF NOT EXISTS idx_daily_cast_attendance_date
+  ON public.daily_cast_attendance(business_date);
+
+-- updated_at 自動更新トリガー
+CREATE OR REPLACE FUNCTION update_daily_cast_attendance_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_daily_cast_attendance_updated_at
+  ON public.daily_cast_attendance;
+
+CREATE TRIGGER trg_daily_cast_attendance_updated_at
+  BEFORE UPDATE ON public.daily_cast_attendance
+  FOR EACH ROW EXECUTE FUNCTION update_daily_cast_attendance_updated_at();

--- a/supabase/migrations/20260426000002_add_cast_shift_request_notifications.sql
+++ b/supabase/migrations/20260426000002_add_cast_shift_request_notifications.sql
@@ -1,0 +1,80 @@
+-- ==========================================
+-- キャスト出勤依頼通知ログテーブル
+-- Phase 2: Shift Shortage Visibility and Attendance Request Logs
+-- ==========================================
+--
+-- 目的: 管理者・スタッフが低人員日にキャストへ出勤依頼を行った記録を保存する。
+-- 実装方針: LINEへの直接送信は行わず、内部ログ + コピー用メッセージ生成のみ。
+-- 重要: channel='internal' のみ。status='sent' はスタッフが手動で送信した場合のみ更新。
+--
+-- 重複防止: business_date + cast_id + channel の組み合わせで
+--           status IN ('pending', 'sent') のレコードが既に存在する場合は追加しない。
+--
+-- RLSパターン: 20260319000000_add_today_dashboard.sql に準拠 (user_roles.user_id)
+-- ==========================================
+
+CREATE TABLE IF NOT EXISTS public.cast_shift_request_notifications (
+  id            uuid        PRIMARY KEY DEFAULT uuid_generate_v4(),
+  business_date date        NOT NULL,
+  cast_id       uuid        NOT NULL REFERENCES public.casts(id) ON DELETE CASCADE,
+  message       text        NOT NULL,
+  status        text        NOT NULL DEFAULT 'pending'
+                  CHECK (status IN ('pending', 'sent', 'failed')),
+  channel       text        NOT NULL DEFAULT 'internal'
+                  CHECK (channel IN ('internal', 'manual')),
+  sent_by       uuid        REFERENCES auth.users(id) ON DELETE SET NULL,
+  sent_at       timestamptz,
+  created_at    timestamptz NOT NULL DEFAULT now(),
+  updated_at    timestamptz NOT NULL DEFAULT now()
+);
+
+ALTER TABLE public.cast_shift_request_notifications ENABLE ROW LEVEL SECURITY;
+
+-- 重複防止: 同一日・同一キャスト・同一チャンネルで pending/sent が既にある場合は追加しない
+CREATE UNIQUE INDEX IF NOT EXISTS cast_shift_request_notif_no_dup
+  ON public.cast_shift_request_notifications (business_date, cast_id, channel)
+  WHERE status IN ('pending', 'sent');
+
+-- 管理者・スタッフ: フルアクセス（user_rolesパターン準拠）
+CREATE POLICY "Admins can manage cast_shift_request_notifications"
+  ON public.cast_shift_request_notifications TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.user_roles
+      WHERE user_roles.user_id = auth.uid()
+        AND user_roles.role IN ('owner', 'manager', 'staff')
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM public.user_roles
+      WHERE user_roles.user_id = auth.uid()
+        AND user_roles.role IN ('owner', 'manager', 'staff')
+    )
+  );
+
+-- インデックス
+CREATE INDEX IF NOT EXISTS idx_cast_shift_request_notif_date
+  ON public.cast_shift_request_notifications(business_date);
+
+CREATE INDEX IF NOT EXISTS idx_cast_shift_request_notif_cast
+  ON public.cast_shift_request_notifications(cast_id);
+
+CREATE INDEX IF NOT EXISTS idx_cast_shift_request_notif_status
+  ON public.cast_shift_request_notifications(status);
+
+-- updated_at 自動更新トリガー
+CREATE OR REPLACE FUNCTION update_cast_shift_request_notifications_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_cast_shift_request_notifications_updated_at
+  ON public.cast_shift_request_notifications;
+
+CREATE TRIGGER trg_cast_shift_request_notifications_updated_at
+  BEFORE UPDATE ON public.cast_shift_request_notifications
+  FOR EACH ROW EXECUTE FUNCTION update_cast_shift_request_notifications_updated_at();


### PR DESCRIPTION
## Summary

- **Phase 1**: Manual daily cast attendance override — admin/staff can mark any cast as `working`, `absent`, or `undecided` from the today-shifts panel. Stored in a new `daily_cast_attendance` table (never touches `daily_checkins`, `shift_submissions`, or `cast_schedules`). Priority chain: manual override → checkin → shift → undecided. Uses `useOptimistic` for instant UI feedback.

- **Phase 2**: Shift shortage visibility and attendance request logs — low-staffed dates (`low`/`critical`) show color-coded staffing badges on the shift management grid. A "依頼" button opens `AttendanceRequestModal` where staff select casts, edit the message, and log the request internally. No LINE API calls; the modal generates a copy-ready message for manual sending.

## Files changed

**Phase 1**
- `supabase/migrations/20260426000001_add_daily_cast_attendance.sql` — new table with RLS (`user_roles.user_id` pattern), unique constraint, `updated_at` trigger
- `lib/actions/today.ts` — `updateDailyCastAttendance` server action
- `lib/actions/dashboard.ts` — fetch override table, apply priority chain, expose `manualStatus` / `finalStatusSource`
- `components/features/admin/dashboard/DashboardTodayShifts.tsx` — summary counts, absent casts visible
- `components/features/admin/dashboard/DashboardTodayShiftsRow.tsx` — optimistic status buttons (出勤/欠勤/—)

**Phase 2**
- `supabase/migrations/20260426000002_add_cast_shift_request_notifications.sql` — notification log table, partial unique index
- `lib/config/shift-staffing.ts` — `MINIMUM_REQUIRED_CASTS`, `getStaffingLevel`
- `lib/actions/schedules.ts` — `computeDailyStaffing`, return `dailyStaffing` from both schedule fetchers
- `lib/actions/notifications.ts` — `sendShiftRequestNotification` with `ignoreDuplicates` upsert
- `components/features/admin/AttendanceRequestModal.tsx` — two-stage modal (selection → success + copy)
- `components/features/admin/ShiftManager.tsx` — staffing badges on date headers, mobile summary row, modal integration
- `app/admin/(protected)/shifts/page.tsx` — pass `dailyStaffing` to ShiftManager

## Test plan

- [ ] Phase 1: Mark a cast as 出勤/欠勤/— in the today panel; verify optimistic update and DB write
- [ ] Phase 1: Confirm `daily_checkins`, `shift_submissions`, `cast_schedules` are untouched
- [ ] Phase 2: Open shifts page; verify low/critical dates show amber/red count badge
- [ ] Phase 2: Click 依頼 on a low/critical date; verify modal opens with non-scheduled casts pre-selected
- [ ] Phase 2: Submit request; verify log written to `cast_shift_request_notifications`, copy message appears
- [ ] Phase 2: Repeat submit for same cast+date; verify duplicate is skipped (`skippedCount` increments)

https://claude.ai/code/session_01Ugsr3qdGWeqo4BeVfYTB7N

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ugsr3qdGWeqo4BeVfYTB7N)_