### PR TITLE
chore(agent): align Animo cursor-ops structure

### DIFF
--- a/.agent/skills/implementation-flow/SKILL.md
+++ b/.agent/skills/implementation-flow/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: implementation-flow
+description: Use when executing a planned multi-step implementation based on PLANS.md.
+metadata:
+  skillport:
+    category: development
+    tags: [implementation, planning, progress, validation]
+---
+
+# Implementation Flow
+
+## Purpose
+
+Execute complex implementation work according to PLANS.md and the user's latest instruction.
+
+## When to Use
+
+Use this skill when:
+- the task has multiple phases
+- multiple files may change
+- another agent may join later
+- progress tracking is required
+- validation and rollback notes are needed
+
+## Workflow
+
+1. Read AGENTS.md.
+2. Read PLANS.md.
+3. Identify the current phase and incomplete tasks.
+4. Confirm the user's latest instruction.
+5. Check for conflicts between the instruction and PLANS.md.
+6. Implement only the approved scope.
+7. Use the smallest safe diff.
+8. Validate the change.
+9. Update task checkboxes in PLANS.md.
+10. Add a progress report.
+
+## Status Markers
+
+- [ ] Not started
+- [~] In progress
+- [x] Completed
+- [!] Blocked
+- [?] Needs decision
+
+## Stop Conditions
+
+Stop and report before changing:
+- database schema
+- authentication
+- permissions
+- payments
+- secrets
+- production settings
+- public URL structure
+- SEO-critical metadata
+- sitemap
+- robots
+- canonical
+- structured data
+
+## Report Format
+
+status:
+- ...
+
+files changed:
+- ...
+
+folders created:
+- ...
+
+folders moved:
+- ...
+
+files moved:
+- ...
+
+files deleted:
+- ...
+
+why:
+- ...
+
+validation:
+- ...
+
+next step:
+- ...

--- a/.agents/skills
+++ b/.agents/skills
@@ -1,1 +1,1 @@
-../.claude/skills
+../.agent/skills

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,42 @@
 # AGENTS.md — Animo
 
+## Implementation Plan Contract
+
+For any project startup, complex change, or multi-step implementation, the agent must follow `PLANS.md`.
+
+`PLANS.md` is the active implementation plan and progress tracker.
+
+Rules:
+- Read `PLANS.md` before starting complex work.
+- Follow `PLANS.md` for complex multi-step work.
+- Follow `PLANS.md` plus the user's latest instruction.
+- Follow the approved implementation plan and the user's latest instruction.
+- Do not perform work outside the current plan unless explicitly instructed.
+- If the user's latest instruction conflicts with `PLANS.md`, stop and report the conflict.
+- Update task status after each completed phase.
+- Mark completed tasks with `[x]`.
+- Keep progress understandable for any agent joining later.
+- Do not remove historical progress unless explicitly instructed.
+- Do not rewrite the entire plan for small updates.
+- Use minimal diffs when updating `PLANS.md`.
+
+Status markers:
+- [ ] Not started
+- [~] In progress
+- [x] Completed
+- [!] Blocked
+- [?] Needs decision
+
+## Skill Directory Policy
+
+- `.agent/skills` is canonical.
+- `.agents/skills` is compatibility only and must remain a symlink.
+- `.claude/skills` may exist for Claude-specific or legacy compatibility and must not be treated as the canonical source unless explicitly instructed.
+- Do not bulk-load all skills.
+- Load full `SKILL.md` only when task-relevant.
+- Do not run `skillport doc` without explicit approval.
+- Do not rely on global `~/.cursor` as the project source of truth.
+
 ## Core Execution Contract
 - Only perform work explicitly requested by the master.
 - Do not expand scope.

--- a/PLANS.md
+++ b/PLANS.md
@@ -1,0 +1,150 @@
+# Implementation Plan
+
+PLANS.md is used only for complex multi-step changes.
+This file is the active implementation plan and progress tracker.
+
+Agents must follow this plan and the user's latest instruction.
+Do not perform work outside this plan unless explicitly instructed.
+
+## Status Legend
+
+- [ ] Not started
+- [~] In progress
+- [x] Completed
+- [!] Blocked
+- [?] Needs decision
+
+## Project Objective
+
+Describe the goal of this project or implementation.
+
+## Current Scope
+
+In scope:
+- ...
+
+Out of scope:
+- ...
+
+## Constraints
+
+- Prefer minimal diffs.
+- Preserve existing architecture.
+- Do not modify unrelated files.
+- Do not change database schema, auth, permissions, payments, secrets, or production settings without explicit approval.
+- Do not change public URLs, SEO-critical metadata, sitemap, robots, canonical, or structured data without explicit approval.
+
+## Impacted Areas
+
+Files:
+- ...
+
+Folders:
+- ...
+
+External services:
+- ...
+
+## Implementation Phases
+
+### Phase 1: Investigation and Structure Check
+
+Status: [ ]
+
+Tasks:
+- [ ] Read AGENTS.md
+- [ ] Read this PLANS.md
+- [ ] Identify impacted files
+- [ ] Confirm existing architecture
+- [ ] Report risks before implementation
+
+Validation:
+- [ ] No files changed unless explicitly needed
+- [ ] Scope confirmed
+
+Rollback notes:
+- No rollback required for read-only investigation
+
+### Phase 2: Minimal Implementation
+
+Status: [ ]
+
+Tasks:
+- [ ] Implement the smallest safe change
+- [ ] Preserve existing behavior outside the requested scope
+- [ ] Avoid unrelated refactors
+
+Validation:
+- [ ] Typecheck if available
+- [ ] Lint if available
+- [ ] Build if safe and relevant
+
+Rollback notes:
+- Revert changed files from this phase if validation fails
+
+### Phase 3: UI / Behavior Verification
+
+Status: [ ]
+
+Tasks:
+- [ ] Verify affected UI or behavior
+- [ ] Check responsive impact if UI changed
+- [ ] Check public route impact if public pages changed
+
+Validation:
+- [ ] Manual verification notes added
+- [ ] Known risks documented
+
+Rollback notes:
+- Revert UI-specific files if layout or behavior breaks
+
+### Phase 4: Final Review and Cleanup
+
+Status: [ ]
+
+Tasks:
+- [ ] Remove temporary code
+- [ ] Confirm no unrelated files changed
+- [ ] Confirm no secrets or sensitive data added
+- [ ] Prepare final report
+
+Validation:
+- [ ] git status reviewed
+- [ ] changed files reviewed
+- [ ] final commands recorded
+
+Rollback notes:
+- Revert final diff if unacceptable
+
+## Progress Log
+
+Use this required report format for implementation updates:
+
+### YYYY-MM-DD
+
+status:
+- ...
+
+files changed:
+- ...
+
+folders created:
+- ...
+
+folders moved:
+- ...
+
+files moved:
+- ...
+
+files deleted:
+- ...
+
+why:
+- ...
+
+validation:
+- ...
+
+next step:
+- ...

--- a/docs/agent-system/implementation-plan-policy.md
+++ b/docs/agent-system/implementation-plan-policy.md
@@ -1,0 +1,63 @@
+# Implementation Plan Policy
+
+## Purpose
+Define the repository-local policy for implementation-plan-based execution so multi-step delivery remains predictable, auditable, and safe.
+
+## Placement
+This policy belongs in the project repository under `docs/agent-system/`.
+Do not treat global `~/.cursor` as the project source of truth.
+
+## Responsibility
+- `PLANS.md` is the active implementation plan and progress tracker.
+- `AGENTS.md` should keep only top-level execution contract rules, including following `PLANS.md` for complex work.
+- Agents execute the plan; users approve scope changes.
+
+## When To Read
+Read this policy before:
+- starting complex multi-step work,
+- updating implementation phases,
+- handing off work to another agent,
+- posting progress reports.
+
+## Execution Rules
+- Follow `PLANS.md` plus the user's latest instruction.
+- Stay within approved scope unless explicitly instructed otherwise.
+- Update task status after each completed phase.
+- Mark completed tasks with `[x]`.
+- Preserve historical progress for continuity and auditability.
+- Do not rewrite the full plan for small updates; apply minimal, targeted edits.
+- Do not work outside the approved plan unless explicitly instructed.
+- Do not rely on global `~/.cursor` as the project source of truth.
+
+Status markers:
+- [ ] Not started
+- [~] In progress
+- [x] Completed
+- [!] Blocked
+- [?] Needs decision
+
+## Conflict Handling
+- If `PLANS.md` conflicts with the user's latest instruction, stop and report before implementation.
+- Surface the exact conflict, impacted phase/task, and required decision.
+- Resume only after explicit direction resolves the conflict.
+
+## Progress Tracking
+- Treat phases as execution checkpoints with status, tasks, validation, and rollback notes.
+- Record progress after meaningful completion points so another agent can continue without context loss.
+- Keep reports factual, scoped, and aligned with actual file changes.
+
+## Stop Conditions
+Stop and report before changing:
+- database schema,
+- authentication or permissions,
+- payments,
+- secrets or production settings,
+- public URL structure,
+- SEO-critical metadata,
+- sitemap, robots, canonical, or structured data.
+
+## Token Efficiency
+- Keep top-level rules in `AGENTS.md` concise.
+- Keep detailed execution guidance in this policy and active tasks in `PLANS.md`.
+- Use metadata/structure first; read only the sections needed for the current phase.
+- Avoid loading unrelated historical plan detail into active context.

--- a/docs/agent-system/progress-report-policy.md
+++ b/docs/agent-system/progress-report-policy.md
@@ -1,0 +1,77 @@
+# Progress Report Policy
+
+## Purpose
+Ensure progress reports make the current project state understandable for any human or AI agent joining later.
+
+## Placement
+This policy belongs in the project repository under `docs/agent-system/`.
+It governs progress reporting for work tracked in `PLANS.md`.
+
+## Responsibility
+- Agents are responsible for reporting phase and delivery progress.
+- Reports must reflect actual changes and actual validation outcomes.
+- Reports must remain factual and concise.
+
+## When To Report
+Agents must report after:
+- Phase 1,
+- Phase 4,
+- final completion,
+- blocked states,
+- validation failures,
+- scope conflicts.
+
+## Required Report Format
+Agents must use this exact structure:
+
+status:
+- ...
+
+files changed:
+- ...
+
+folders created:
+- ...
+
+folders moved:
+- ...
+
+files moved:
+- ...
+
+files deleted:
+- ...
+
+why:
+- ...
+
+validation:
+- ...
+
+next step:
+- ...
+
+## Status Markers
+
+- [ ] Not started
+- [~] In progress
+- [x] Completed
+- [!] Blocked
+- [?] Needs decision
+
+## Reporting Rules
+- Keep reports factual and concise.
+- List changed files accurately.
+- Report `none` when no files or folders changed.
+- Do not hide failed validation.
+- Do not claim completion unless validation was run, or explicitly skipped with a reason.
+
+## Validation Reporting
+- State what validation was run and the result.
+- If validation was skipped, state that clearly and explain why.
+- If validation failed, report the failure and current impact.
+
+## Token Efficiency
+- Use the exact report structure to keep updates compact and scannable.
+- Include only task-relevant reporting detail; avoid unrelated narrative.
+- Do not duplicate full policy text from `AGENTS.md`, `PLANS.md`, or implementation-plan policy docs.

--- a/docs/agent-system/skillport.md
+++ b/docs/agent-system/skillport.md
@@ -1,0 +1,95 @@
+# SkillPort Policy
+
+## Purpose
+Define repository-local policy for using SkillPort as a management, validation, search/discovery, lifecycle, and MCP delivery layer.
+SkillPort is not the source of truth for skills.
+
+## Placement
+This policy belongs in `docs/agent-system/` inside each project repository.
+Do not use global `~/.cursor` as the project source of truth.
+
+## Responsibility
+- `.agent/skills` remains canonical.
+- `.agents/skills` is compatibility only and must be a symlink to `.agent/skills`.
+- SkillPort manages discovery/validation/lifecycle/delivery workflows, not canonical skill ownership.
+
+## When To Read
+Read before:
+- validating or importing skills,
+- changing skill directories or compatibility links,
+- enabling SkillPort MCP delivery,
+- updating skill metadata or lifecycle state.
+
+## Token Efficiency
+- Use metadata-first discovery (`skillport list`, `skillport meta`, `skillport show <id>`).
+- Load full `SKILL.md` only when task-relevant.
+- Do not bulk-load all skills.
+- Do not treat Shared Vault as always-loaded context.
+
+## Directory Strategy
+- Keep canonical skill content in `.agent/skills`.
+- Keep `.agents/skills` as symlink compatibility only.
+- Do not create `.agents/skills` as a real directory.
+- Do not maintain parallel skill trees with duplicated content.
+
+## Safe Commands
+Read-only commands that are generally safe:
+
+```bash
+skillport --help
+skillport list
+skillport show <id>
+skillport meta
+skillport validate
+```
+
+## Commands Requiring Approval
+Commands that can change repository state or sources:
+
+```bash
+skillport add ...
+skillport remove ...
+skillport update ...
+skillport init ...
+```
+
+Also requires explicit approval:
+- installing SkillPort tools,
+- installing third-party skills from external sources.
+
+Install commands (when approved):
+
+```bash
+uv tool install skillport
+uv tool install skillport-mcp
+```
+
+## Forbidden Commands/Actions
+- Do not use `npx` for SkillPort.
+- Do not run `skillport doc` without explicit approval.
+- Do not create `.agents/skills` as a real directory.
+- Do not treat SkillPort as skill source-of-truth.
+- Do not assume Shared Vault content is always loaded.
+
+## Cursor MCP Example
+Example launch flow (after approved install):
+
+```bash
+uvx skillport-mcp
+```
+
+SkillPort MCP should be used as a delivery/access layer, while canonical skill files stay in `.agent/skills`.
+
+## Symlink Policy
+- Required compatibility mapping: `.agents/skills -> ../.agent/skills` (or equivalent path from `.agents`).
+- If `.agents/skills` exists and is not a symlink, stop and request migration approval.
+- If symlink creation fails, stop and report.
+
+## Stop Conditions
+Stop and request explicit approval when:
+- a command may write or restructure files unexpectedly,
+- skill source ownership may shift away from `.agent/skills`,
+- `.agents/skills` exists as a real directory,
+- installing third-party skills is requested without approval,
+- `skillport doc` is requested without approval,
+- command behavior is unclear from help output.


### PR DESCRIPTION
Summary:
- Add PLANS.md as the implementation plan and progress tracker.
- Add implementation-flow skill under canonical .agent/skills.
- Add agent-system policies for implementation plans, progress reports, and SkillPort.
- Repoint .agents/skills compatibility symlink to .agent/skills.
- Preserve .claude/skills as Claude-specific or legacy compatibility.
- Preserve existing Animo-specific AGENTS.md rules.

Validation:
- Confirmed .agents/skills -> ../.agent/skills.
- Confirmed .claude/skills still exists.
- Confirmed no application source files were modified.
- Confirmed no package, env, DB, auth, payment, secrets, or production settings were modified.

Risk:
- Low. Policy/docs/symlink-only change.
- Main operational change is that .agents/skills now resolves to .agent/skills instead of .claude/skills.