### PR TITLE
fix(register): add nameKana field to cast registration forms; redesig…

### DIFF
--- a/app/(cast)/cast/m/register/page.tsx
+++ b/app/(cast)/cast/m/register/page.tsx
@@ -209,6 +209,19 @@ export default function CastRegisterMobilePage() {
 
             <div>
               <label className="block text-xs mb-1.5" style={{ color: '#9f9fa9' }}>
+                フリガナ
+              </label>
+              <input
+                name="nameKana"
+                required
+                className="w-full rounded-[10px] px-[10px] py-[6px] text-sm text-white placeholder-[#71717b] focus:outline-none focus-visible:ring-2 focus-visible:ring-[#dfbd69]/25"
+                placeholder="ヤマダ タロウ"
+                style={{ background: '#27272a', border: '0.617px solid #3f3f47' }}
+              />
+            </div>
+
+            <div>
+              <label className="block text-xs mb-1.5" style={{ color: '#9f9fa9' }}>
                 源氏名
               </label>
               <input

--- a/app/(cast)/cast/profile/page.tsx
+++ b/app/(cast)/cast/profile/page.tsx
@@ -1,6 +1,16 @@
 import { redirect } from 'next/navigation';
-import { ShieldCheck, CalendarRange } from 'lucide-react';
-import { getCurrentCast, castLogout } from '@/lib/actions/cast-auth';
+import {
+  ShieldCheck,
+  CalendarRange,
+  Eye,
+  Trophy,
+  Pencil,
+  ImageIcon,
+  LogOut,
+  ChevronRight,
+} from 'lucide-react';
+import { getCurrentCast, castLogout, getMyCastPosts } from '@/lib/actions/cast-auth';
+import { getCastPVStats } from '@/lib/actions/posts-analytics';
 import { PlaceholderImage } from '@/components/ui/PlaceholderImage';
 import Link from 'next/link';
 import {
@@ -8,7 +18,9 @@ import {
   CastMobileCard,
   CastMobileHeader,
   CastMobileShell,
+  CastMobileHeaderBell,
 } from '@/components/features/cast/CastMobileShell';
+import Image from 'next/image';
 
 type CastPrivateInfo = {
   real_name?: string | null;
@@ -29,33 +41,20 @@ function resolveBaseDate(raw: string | null | undefined) {
 function formatTenure(baseDateRaw: string | null | undefined) {
   const baseDate = resolveBaseDate(baseDateRaw);
   if (!baseDate) return '-';
-
   const now = new Date();
   const diffInDays = Math.max(0, Math.floor((now.getTime() - baseDate.getTime()) / (1000 * 60 * 60 * 24)));
-
-  if (diffInDays < 30) {
-    return `${diffInDays}日`;
-  }
-
+  if (diffInDays < 30) return `${diffInDays}日`;
   const months = Math.floor(diffInDays / 30);
-  if (months < 12) {
-    return `${months}か月`;
-  }
-
+  if (months < 12) return `${months}ヶ月`;
   const years = Math.floor(months / 12);
   const remainingMonths = months % 12;
-
-  if (remainingMonths === 0) {
-    return `${years}年`;
-  }
-
-  return `${years}年${remainingMonths}か月`;
+  return remainingMonths === 0 ? `${years}年` : `${years}年${remainingMonths}ヶ月`;
 }
 
 function formatJoinedDate(baseDateRaw: string | null | undefined) {
   const baseDate = resolveBaseDate(baseDateRaw);
   if (!baseDate) return '-';
-  return baseDate.toLocaleDateString('ja-JP');
+  return `${baseDate.getFullYear()}/${String(baseDate.getMonth() + 1).padStart(2, '0')}/${String(baseDate.getDate()).padStart(2, '0')}`;
 }
 
 export default async function CastProfilePage() {
@@ -68,68 +67,187 @@ export default async function CastProfilePage() {
   const realName = privateInfo?.real_name || '-';
   const joinedBaseDate = cast.joined_at || cast.created_at || null;
 
-  const metrics = [
-    { icon: CalendarRange, value: formatTenure(joinedBaseDate), label: '在籍期間' },
-    { icon: ShieldCheck, value: '算出中', label: '出勤率' },
-  ];
+  const [pvResult, postsResult] = await Promise.all([
+    getCastPVStats(cast.id as string),
+    getMyCastPosts(cast.id as string),
+  ]);
 
-  const details = [
-    { label: '本名', value: realName },
-    { label: 'ステージ名', value: cast.stage_name || '-' },
-    { label: '所属店舗', value: cast.store_name || 'Club Animo Shinjuku' },
-    { label: '入店日', value: formatJoinedDate(joinedBaseDate) },
-  ];
+  const totalPV = pvResult.success ? pvResult.totalPV : 0;
+  const pvRank = pvResult.success ? pvResult.rank : '-';
+  const totalCasts = pvResult.success ? pvResult.totalCasts : 0;
+  const publishedPosts = postsResult.data?.filter((p) => p.status === 'published') ?? [];
+  const recentPosts = publishedPosts.slice(0, 4);
+  const totalPostCount = postsResult.data?.length ?? 0;
 
   return (
     <CastMobileShell>
-      <CastMobileHeader leftSlot={<CastMobileBackLink href="/cast/dashboard" label="ダッシュボードへ戻る" />} />
-      <main className="mx-auto flex w-full max-w-[422px] flex-col gap-[19px] px-4 pb-28 pt-6">
+      <CastMobileHeader
+        leftSlot={<CastMobileBackLink href="/cast/dashboard" label="ダッシュボード" />}
+        rightSlot={<CastMobileHeaderBell />}
+      />
 
-        <CastMobileCard className="rounded-[16px] px-6 py-6 text-center">
-          <div className="mx-auto flex h-20 w-20 items-center justify-center overflow-hidden rounded-full border-[1.8px] border-[rgba(201,167,106,0.3)] bg-[rgba(201,167,106,0.15)]">
-            <PlaceholderImage
-              src={cast.image_url}
-              alt={cast.stage_name || realName}
-              ratio="square"
-              placeholderText={cast.stage_name || realName}
-              className="h-full w-full object-cover"
-            />
+      <main className="mx-auto w-full max-w-[422px] px-4 pt-5 pb-28 space-y-3">
+
+        {/* ── Hero Card ── */}
+        <CastMobileCard className="rounded-[20px] overflow-hidden p-0">
+          {/* Gold gradient top strip */}
+          <div
+            className="h-[6px] w-full"
+            style={{ background: 'linear-gradient(90deg, rgb(223,189,105) 0%, rgb(146,111,52) 100%)' }}
+          />
+          <div className="px-6 pt-5 pb-6 text-center">
+            <div className="relative mx-auto mb-4 w-[80px] h-[80px]">
+              <div
+                className="w-full h-full rounded-full overflow-hidden border-[2px]"
+                style={{ borderColor: 'rgba(201,167,106,0.5)' }}
+              >
+                <PlaceholderImage
+                  src={cast.image_url}
+                  alt={cast.stage_name || realName}
+                  ratio="square"
+                  placeholderText={cast.stage_name || realName}
+                  className="h-full w-full object-cover"
+                />
+              </div>
+              <Link
+                href="/cast/profile/edit"
+                className="absolute -bottom-1 -right-1 flex h-[26px] w-[26px] items-center justify-center rounded-full border border-[rgba(201,167,106,0.3)] bg-[#1a1c22]"
+              >
+                <Pencil className="h-[12px] w-[12px] text-[#c9a76a]" />
+              </Link>
+            </div>
+
+            <h1 className="text-[20px] font-bold text-[#f7f4ed] leading-tight">
+              {cast.stage_name || realName}
+            </h1>
+            <p className="mt-[2px] text-[12px] text-[#6b7280]">{realName}</p>
+            <p className="mt-[2px] text-[11px] font-medium" style={{ color: '#c9a76a' }}>
+              {cast.store_name || 'Club Animo'}
+            </p>
+
+            <div className="mt-4 flex gap-2">
+              <Link
+                href="/cast/profile/edit"
+                className="flex flex-1 items-center justify-center gap-1.5 rounded-[12px] py-2.5 text-[13px] font-bold"
+                style={{
+                  background: 'linear-gradient(90deg, rgb(223,189,105) 0%, rgb(146,111,52) 100%)',
+                  color: '#0b0b0d',
+                }}
+              >
+                <Pencil className="h-[13px] w-[13px]" />
+                プロフィール編集
+              </Link>
+            </div>
           </div>
-          <h1 className="mt-[14px] text-[22px] font-bold leading-[33px] text-[#f7f4ed]">{cast.stage_name || realName}</h1>
-          <p className="mt-[2px] text-[13px] leading-[19.5px] text-[#6b7280]">{realName}</p>
-          <p className="mt-[2px] text-[12px] leading-[18px] text-[#c9a76a]">{cast.store_name || 'Club Animo Shinjuku'}</p>
-          <Link href="/cast/profile/edit" className="mt-[16px] inline-flex items-center gap-2 rounded-[14px] border border-[rgba(201,167,106,0.2)] bg-[rgba(201,167,106,0.15)] px-4 py-[9px] text-[13px] font-bold leading-[19.5px] text-[#c9a76a]">
-            プロフィールを編集
-          </Link>
         </CastMobileCard>
 
-        <div className="grid grid-cols-3 gap-3">
-          {metrics.map((metric) => (
-            <CastMobileCard key={metric.label} className="rounded-[14px] px-3 py-4 text-center">
-              <metric.icon className="mx-auto h-[18px] w-[18px] text-[#c9a76a]" strokeWidth={1.8} />
-              <div className="mt-[8px] text-[16px] font-bold leading-6 text-[#f7f4ed]">{metric.value}</div>
-              <div className="mt-[2px] text-[11px] leading-[16.5px] text-[#6b7280]">{metric.label}</div>
+        {/* ── Stats Grid ── */}
+        <div className="grid grid-cols-4 gap-2">
+          {[
+            { icon: CalendarRange, value: formatTenure(joinedBaseDate), label: '在籍' },
+            { icon: Eye, value: totalPV > 999 ? `${(totalPV / 1000).toFixed(1)}k` : String(totalPV), label: '総PV' },
+            { icon: Trophy, value: pvRank !== '-' && totalCasts > 0 ? `${String(pvRank)}位` : '-', label: 'ランク' },
+            { icon: ShieldCheck, value: String(publishedPosts.length), label: '公開記事' },
+          ].map((stat) => (
+            <CastMobileCard key={stat.label} className="rounded-[14px] px-2 py-3 text-center">
+              <stat.icon className="mx-auto h-[16px] w-[16px] text-[#c9a76a]" strokeWidth={1.8} />
+              <div className="mt-[6px] text-[14px] font-bold leading-none text-[#f7f4ed]">{stat.value}</div>
+              <div className="mt-[3px] text-[10px] leading-none text-[#6b7280]">{stat.label}</div>
             </CastMobileCard>
           ))}
         </div>
 
-        <CastMobileCard className="overflow-hidden rounded-[16px] divide-y divide-white/8">
-          {details.map((detail) => (
-            <div key={detail.label} className="flex items-center justify-between px-5 py-4">
-              <span className="text-[13px] leading-[19.5px] text-[#6b7280]">{detail.label}</span>
-              <span className="text-[13px] font-medium leading-[19.5px] text-[#f7f4ed]">{detail.value}</span>
+        {/* ── Profile Details ── */}
+        <CastMobileCard className="overflow-hidden rounded-[16px] divide-y divide-white/[0.06]">
+          {[
+            { label: '本名', value: realName },
+            { label: 'ステージ名', value: cast.stage_name || '-' },
+            { label: '所属店舗', value: cast.store_name || 'Club Animo' },
+            { label: '入店日', value: formatJoinedDate(joinedBaseDate) },
+            { label: '総投稿数', value: `${totalPostCount}件` },
+          ].map((row) => (
+            <div key={row.label} className="flex items-center justify-between px-5 py-[14px]">
+              <span className="text-[12px] text-[#6b7280]">{row.label}</span>
+              <span className="text-[13px] font-medium text-[#f7f4ed]">{row.value}</span>
             </div>
           ))}
         </CastMobileCard>
 
+        {/* ── Recent Posts ── */}
+        {recentPosts.length > 0 && (
+          <div className="space-y-2">
+            <div className="flex items-center justify-between px-1">
+              <div className="flex items-center gap-2">
+                <ImageIcon className="h-[13px] w-[13px] text-[#c9a76a]" />
+                <span className="text-[12px] font-semibold text-[#c7c0b2]">最近の投稿</span>
+              </div>
+              <Link href="/cast/posts" className="text-[11px] text-[#c9a76a] flex items-center gap-0.5">
+                すべて見る
+                <ChevronRight className="h-[11px] w-[11px]" />
+              </Link>
+            </div>
+            <div className="grid grid-cols-2 gap-2">
+              {recentPosts.map((post) => (
+                <CastMobileCard
+                  key={post.id}
+                  className="rounded-[14px] overflow-hidden p-0 aspect-[4/5] relative"
+                >
+                  {post.image_url ? (
+                    <Image
+                      src={post.image_url}
+                      alt="投稿画像"
+                      fill
+                      className="object-cover"
+                    />
+                  ) : (
+                    <div className="absolute inset-0 flex items-center justify-center bg-[#1c1d22]">
+                      <ImageIcon className="h-[20px] w-[20px] text-[#5a5650]" />
+                    </div>
+                  )}
+                  <div className="absolute bottom-0 left-0 right-0 bg-gradient-to-t from-black/80 to-transparent px-2.5 py-2">
+                    <div className="flex items-center gap-1 text-[10px] text-[#c7c0b2]">
+                      <Eye className="h-[10px] w-[10px]" />
+                      {(post.view_count ?? 0).toLocaleString()}
+                    </div>
+                  </div>
+                </CastMobileCard>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* ── Quick Links ── */}
+        <CastMobileCard className="overflow-hidden rounded-[16px] divide-y divide-white/[0.06]">
+          {[
+            { href: '/cast/posts', label: '自分の投稿を管理', icon: ImageIcon },
+            { href: '/cast/shift', label: 'シフト申請', icon: CalendarRange },
+            { href: '/cast/notices', label: 'お知らせを確認', icon: ShieldCheck },
+          ].map((item) => (
+            <Link
+              key={item.href}
+              href={item.href}
+              className="flex items-center justify-between px-5 py-[14px] hover:bg-white/[0.03] transition-colors"
+            >
+              <div className="flex items-center gap-3">
+                <item.icon className="h-[14px] w-[14px] text-[#c9a76a]" strokeWidth={1.8} />
+                <span className="text-[13px] text-[#c7c0b2]">{item.label}</span>
+              </div>
+              <ChevronRight className="h-[14px] w-[14px] text-[#5a5650]" />
+            </Link>
+          ))}
+        </CastMobileCard>
+
+        {/* ── Logout ── */}
         <form action={castLogout}>
           <button
             type="submit"
-            className="w-full rounded-[14px] border border-[rgba(224,106,106,0.2)] bg-[rgba(224,106,106,0.12)] px-4 py-3 text-[14px] font-bold leading-[21px] text-[#e06a6a]"
+            className="flex w-full items-center justify-center gap-2 rounded-[14px] border border-[rgba(224,106,106,0.2)] bg-[rgba(224,106,106,0.08)] px-4 py-3 text-[13px] font-bold text-[#e06a6a] transition-colors hover:bg-[rgba(224,106,106,0.14)]"
           >
+            <LogOut className="h-[14px] w-[14px]" />
             ログアウト
           </button>
         </form>
+
       </main>
     </CastMobileShell>
   );

--- a/app/(cast)/cast/register/page.tsx
+++ b/app/(cast)/cast/register/page.tsx
@@ -209,6 +209,19 @@ export default function CastRegisterPage() {
 
             <div>
               <label className="block text-xs mb-1.5" style={{ color: '#9f9fa9' }}>
+                フリガナ
+              </label>
+              <input
+                name="nameKana"
+                required
+                className="w-full rounded-[10px] px-[10px] py-[6px] text-sm text-white placeholder-[#71717b] focus:outline-none focus-visible:ring-2 focus-visible:ring-[#dfbd69]/25"
+                placeholder="ヤマダ タロウ"
+                style={{ background: '#27272a', border: '0.556px solid #3f3f47' }}
+              />
+            </div>
+
+            <div>
+              <label className="block text-xs mb-1.5" style={{ color: '#9f9fa9' }}>
                 源氏名
               </label>
               <input

--- a/app/admin/(protected)/analytics/page.tsx
+++ b/app/admin/(protected)/analytics/page.tsx
@@ -1,96 +1,227 @@
 import { getAnalyticsSummary } from '@/lib/actions/analytics'
-import { BarChart2, TrendingUp, TrendingDown, Eye, Activity } from 'lucide-react'
+import { getAdminPostRankings } from '@/lib/actions/posts-analytics'
+import {
+  BarChart2,
+  TrendingUp,
+  TrendingDown,
+  Eye,
+  Activity,
+  FileText,
+  Trophy,
+  Minus,
+} from 'lucide-react'
+import Image from 'next/image'
 
 export const dynamic = 'force-dynamic'
 
-function StatCard({
-  label, value, unit = '', sub = '', trend = null,
-}: {
-  label: string
-  value: string | number
-  unit?: string
-  sub?: string
-  trend?: 'up' | 'down' | null
-}) {
-  return (
-    <div className="bg-[#17181c] rounded-[18px] border border-[#ffffff0f] px-5 py-5">
-      <p className="text-[10px] font-medium text-[#5a5650] tracking-[0.6px] uppercase mb-2">{label}</p>
-      <div className="flex items-baseline gap-1.5">
-        <span className="text-[28px] font-bold text-[#f4f1ea] leading-none">{value}</span>
-        {unit && <span className="text-[12px] text-[#8a8478]">{unit}</span>}
-        {trend === 'up'   && <TrendingUp  size={14} className="text-[#72b894] mb-0.5" />}
-        {trend === 'down' && <TrendingDown size={14} className="text-[#d4785a] mb-0.5" />}
-      </div>
-      {sub && <p className="text-[11px] text-[#8a8478] mt-1">{sub}</p>}
-    </div>
-  )
-}
-
 export default async function AnalyticsPage() {
-  const analytics = await getAnalyticsSummary()
-  const { todayPv, yesterdayPv, activeUsers } = analytics
+  const [analytics, rankingsResult] = await Promise.all([
+    getAnalyticsSummary(),
+    getAdminPostRankings(10),
+  ])
 
-  const pvDiff   = todayPv - yesterdayPv
-  const pvChange = yesterdayPv > 0
-    ? ((pvDiff / yesterdayPv) * 100).toFixed(1)
-    : null
+  const { todayPv, yesterdayPv, activeUsers } = analytics
+  const pvDiff    = todayPv - yesterdayPv
+  const pvChange  = yesterdayPv > 0 ? ((pvDiff / yesterdayPv) * 100).toFixed(1) : null
+  const rankedPosts = rankingsResult.success ? (rankingsResult.data ?? []) : []
+
+  const kpis = [
+    {
+      label: '本日 PV',
+      value: todayPv.toLocaleString(),
+      unit: 'PV',
+      sub: '本日累計',
+      trend: pvDiff > 0 ? 'up' : pvDiff < 0 ? 'down' : 'flat',
+      color: 'text-[#dfbd69]',
+      bg: 'bg-[#dfbd6914]',
+      icon: Eye,
+    },
+    {
+      label: '昨日 PV',
+      value: yesterdayPv.toLocaleString(),
+      unit: 'PV',
+      sub: '前日実績',
+      trend: 'flat' as const,
+      color: 'text-[#8a8478]',
+      bg: 'bg-[#ffffff08]',
+      icon: BarChart2,
+    },
+    {
+      label: 'アクティブ',
+      value: String(activeUsers),
+      unit: '名',
+      sub: '直近5分',
+      trend: activeUsers > 0 ? 'up' : 'flat',
+      color: 'text-[#72b894]',
+      bg: 'bg-[#72b89414]',
+      icon: Activity,
+    },
+    {
+      label: 'PV変化率',
+      value: pvChange !== null ? `${parseFloat(pvChange) >= 0 ? '+' : ''}${pvChange}` : '–',
+      unit: pvChange !== null ? '%' : '',
+      sub: '前日比',
+      trend: pvChange !== null ? (parseFloat(pvChange) >= 0 ? 'up' : 'down') : 'flat',
+      color: pvChange !== null && parseFloat(pvChange) >= 0 ? 'text-[#72b894]' : 'text-[#d4785a]',
+      bg: pvChange !== null && parseFloat(pvChange) >= 0 ? 'bg-[#72b89414]' : 'bg-[#d4785a14]',
+      icon: pvChange !== null && parseFloat(pvChange) >= 0 ? TrendingUp : TrendingDown,
+    },
+  ]
 
   return (
-    <div className="space-y-6 font-inter">
+    <div className="space-y-5 font-inter">
+
       {/* ── Page Header ── */}
       <div className="flex flex-col gap-0.5 py-2">
-        <h1 className="text-[17px] font-semibold text-[#f4f1ea] tracking-[-0.31px]">サイト分析</h1>
+        <h1 className="text-[17px] font-semibold tracking-[-0.31px] text-[#f4f1ea]">サイト分析</h1>
         <p className="text-[11px] text-[#8a8478]">サイトトラフィックとコンテンツパフォーマンス</p>
       </div>
 
-      {/* ── KPI Cards ── */}
+      {/* ── KPI Grid ── */}
       <div className="grid grid-cols-2 lg:grid-cols-4 gap-3">
-        <StatCard label="本日のPV" value={todayPv} unit="PV" sub="本日累計" trend={pvDiff > 0 ? 'up' : pvDiff < 0 ? 'down' : null} />
-        <StatCard label="昨日のPV" value={yesterdayPv} unit="PV" sub="前日比較" />
-        <StatCard label="アクティブ" value={activeUsers} unit="名" sub="直近5分" trend={activeUsers > 0 ? 'up' : null} />
-        <StatCard
-          label="PV変化率"
-          value={pvChange !== null ? `${pvChange > '0' ? '+' : ''}${pvChange}` : '–'}
-          unit={pvChange !== null ? '%' : ''}
-          sub="前日比"
-          trend={pvChange !== null ? (parseFloat(pvChange) >= 0 ? 'up' : 'down') : null}
-        />
-      </div>
-
-      {/* ── Traffic Overview ── */}
-      <div className="bg-[#17181c] rounded-[18px] border border-[#ffffff0f] overflow-hidden">
-        <div className="flex items-center gap-3 px-5 h-[56px] border-b border-[#ffffff08]">
-          <div className="w-[28px] h-[28px] flex items-center justify-center bg-[#dfbd691a] rounded-[7px]">
-            <BarChart2 size={14} className="text-[#dfbd69]" />
-          </div>
-          <div>
-            <p className="text-[12px] font-semibold text-[#f4f1ea]">トラフィック概要</p>
-            <p className="text-[10px] text-[#5a5650]">本日のアクセス状況</p>
-          </div>
-        </div>
-        <div className="p-5 space-y-3">
-          {[
-            { label: '本日のページビュー',   value: todayPv,     icon: Eye,      color: 'text-[#dfbd69]', bg: 'bg-[#dfbd6914]' },
-            { label: '昨日のページビュー',   value: yesterdayPv, icon: Eye,      color: 'text-[#8a8478]', bg: 'bg-[#ffffff08]' },
-            { label: 'アクティブユーザー',   value: activeUsers, icon: Activity, color: 'text-[#72b894]', bg: 'bg-[#72b89414]' },
-          ].map((row) => (
-            <div key={row.label} className="flex items-center gap-3 h-[44px] px-3 rounded-[10px] hover:bg-[#ffffff04] transition-colors">
-              <div className={`w-[30px] h-[30px] flex items-center justify-center rounded-[8px] ${row.bg} shrink-0`}>
-                <row.icon size={14} className={row.color} />
+        {kpis.map((k) => (
+          <div
+            key={k.label}
+            className="bg-[#17181c] rounded-[18px] border border-[#ffffff0f] px-5 py-4 flex flex-col gap-2"
+          >
+            <div className="flex items-center justify-between">
+              <p className="text-[10px] font-medium uppercase tracking-[0.6px] text-[#5a5650]">{k.label}</p>
+              <div className={`flex h-[28px] w-[28px] items-center justify-center rounded-[8px] ${k.bg}`}>
+                <k.icon size={13} className={k.color} />
               </div>
-              <span className="text-[12px] text-[#c7c0b2] flex-1">{row.label}</span>
-              <span className={`text-[14px] font-bold ${row.color}`}>{row.value.toLocaleString()}</span>
             </div>
-          ))}
-        </div>
+            <div className="flex items-baseline gap-1.5">
+              <span className={`text-[28px] font-bold leading-none ${k.color}`}>{k.value}</span>
+              {k.unit && <span className="text-[12px] text-[#8a8478]">{k.unit}</span>}
+              {k.trend === 'up'   && <TrendingUp  size={13} className="text-[#72b894]" />}
+              {k.trend === 'down' && <TrendingDown size={13} className="text-[#d4785a]" />}
+              {k.trend === 'flat' && <Minus size={13} className="text-[#5a5650]" />}
+            </div>
+            <p className="text-[10px] text-[#8a8478]">{k.sub}</p>
+          </div>
+        ))}
       </div>
 
-      {/* ── Data Source Note ── */}
-      <div className="bg-[#17181c] rounded-[18px] border border-[#ffffff0f] p-5">
-        <p className="text-[11px] text-[#5a5650] leading-relaxed">
-          ※ アクセスデータは <code className="text-[#dfbd69] bg-[#dfbd6910] px-1.5 py-0.5 rounded text-[10px]">site_analytics</code> テーブルから取得しています。
-          リアルタイムのアクティブユーザーは直近5分以内のアクセスを集計しています。
-        </p>
+      {/* ── Two-Column Layout ── */}
+      <div className="grid grid-cols-1 xl:grid-cols-2 gap-5 items-start">
+
+        {/* Left: Traffic Overview */}
+        <div className="bg-[#17181c] rounded-[18px] border border-[#ffffff0f] overflow-hidden">
+          <div className="flex items-center gap-3 px-5 h-[52px] border-b border-[#ffffff08]">
+            <div className="flex h-[28px] w-[28px] items-center justify-center rounded-[7px] bg-[#dfbd6914]">
+              <BarChart2 size={13} className="text-[#dfbd69]" />
+            </div>
+            <p className="text-[12px] font-semibold text-[#f4f1ea]">トラフィック概要</p>
+          </div>
+
+          <div className="p-5 space-y-2">
+            {[
+              { label: '本日のページビュー',   value: todayPv,     color: 'text-[#dfbd69]', bar: todayPv,     max: Math.max(todayPv, yesterdayPv) || 1 },
+              { label: '昨日のページビュー',   value: yesterdayPv, color: 'text-[#8a8478]', bar: yesterdayPv, max: Math.max(todayPv, yesterdayPv) || 1 },
+              { label: 'アクティブユーザー',   value: activeUsers, color: 'text-[#72b894]', bar: activeUsers,  max: Math.max(activeUsers, 1) },
+            ].map((row) => (
+              <div key={row.label} className="space-y-1">
+                <div className="flex items-center justify-between text-[11px]">
+                  <span className="text-[#c7c0b2]">{row.label}</span>
+                  <span className={`font-bold tabular-nums ${row.color}`}>{row.value.toLocaleString()}</span>
+                </div>
+                <div className="h-[4px] w-full rounded-full bg-[#ffffff08] overflow-hidden">
+                  <div
+                    className="h-full rounded-full transition-all"
+                    style={{
+                      width: `${Math.min(100, (row.bar / row.max) * 100)}%`,
+                      background: row.label.includes('昨日') ? '#8a8478' : row.label.includes('アクティブ') ? '#72b894' : 'linear-gradient(90deg,#dfbd69,#926f34)',
+                    }}
+                  />
+                </div>
+              </div>
+            ))}
+
+            <div className="mt-3 rounded-[10px] border border-[#ffffff08] bg-[#1c1d22] px-4 py-3">
+              <p className="text-[10px] text-[#5a5650] leading-relaxed">
+                アクティブユーザーは直近5分以内のユニークアクセスを集計。
+                PVは <code className="text-[#dfbd69] text-[9px]">site_analytics</code> テーブルから取得。
+              </p>
+            </div>
+          </div>
+        </div>
+
+        {/* Right: Post Rankings */}
+        <div className="bg-[#17181c] rounded-[18px] border border-[#ffffff0f] overflow-hidden">
+          <div className="flex items-center gap-3 px-5 h-[52px] border-b border-[#ffffff08]">
+            <div className="flex h-[28px] w-[28px] items-center justify-center rounded-[7px] bg-[#a882d814]">
+              <Trophy size={13} className="text-[#a882d8]" />
+            </div>
+            <div>
+              <p className="text-[12px] font-semibold text-[#f4f1ea]">投稿 PV ランキング</p>
+            </div>
+            <span className="ml-auto text-[10px] text-[#5a5650]">TOP {rankedPosts.length}</span>
+          </div>
+
+          {rankedPosts.length === 0 ? (
+            <div className="py-16 text-center">
+              <FileText size={22} className="mx-auto mb-3 text-[#5a5650]" />
+              <p className="text-[12px] text-[#5a5650] italic">投稿データがありません</p>
+            </div>
+          ) : (
+            <div className="divide-y divide-[#ffffff06]">
+              {rankedPosts.map((post, idx) => {
+                const cast = post.casts
+                const pv = post.view_count ?? 0
+                const maxPv = rankedPosts[0]?.view_count ?? 1
+                const medal = idx === 0 ? '🥇' : idx === 1 ? '🥈' : idx === 2 ? '🥉' : null
+                return (
+                  <div key={post.id} className="flex items-center gap-3 px-4 py-3 hover:bg-[#ffffff04] transition-colors">
+                    {/* Rank */}
+                    <div className="w-[22px] shrink-0 text-center">
+                      {medal ? (
+                        <span className="text-[14px]">{medal}</span>
+                      ) : (
+                        <span className="text-[11px] font-bold text-[#5a5650]">{idx + 1}</span>
+                      )}
+                    </div>
+
+                    {/* Thumbnail */}
+                    <div className="relative h-[36px] w-[36px] shrink-0 overflow-hidden rounded-[8px] bg-[#1c1d22]">
+                      {post.image_url ? (
+                        <Image src={post.image_url} alt="" fill className="object-cover" />
+                      ) : (
+                        <div className="flex h-full w-full items-center justify-center">
+                          <FileText size={14} className="text-[#5a5650]" />
+                        </div>
+                      )}
+                    </div>
+
+                    {/* Info */}
+                    <div className="min-w-0 flex-1">
+                      <p className="truncate text-[11px] font-medium text-[#c7c0b2]">
+                        {cast?.stage_name ?? '–'}
+                      </p>
+                      <div className="mt-0.5 h-[3px] w-full rounded-full bg-[#ffffff08] overflow-hidden">
+                        <div
+                          className="h-full rounded-full"
+                          style={{
+                            width: `${Math.min(100, (pv / (maxPv || 1)) * 100)}%`,
+                            background: idx === 0 ? 'linear-gradient(90deg,#dfbd69,#926f34)' : '#5a5650',
+                          }}
+                        />
+                      </div>
+                    </div>
+
+                    {/* PV */}
+                    <div className="flex items-center gap-1 shrink-0">
+                      <Eye size={10} className="text-[#5a5650]" />
+                      <span className="text-[12px] font-bold text-[#f4f1ea] tabular-nums">
+                        {pv.toLocaleString()}
+                      </span>
+                    </div>
+                  </div>
+                )
+              })}
+            </div>
+          )}
+        </div>
+
       </div>
     </div>
   )

--- a/app/admin/(protected)/contents/page.tsx
+++ b/app/admin/(protected)/contents/page.tsx
@@ -1,11 +1,16 @@
 import { getContents, deleteContent } from '@/lib/actions/contents'
 import Link from 'next/link'
-import { Plus, Edit2, Trash2, Newspaper } from 'lucide-react'
 import { revalidatePath } from 'next/cache'
+import { Plus, Edit2, Trash2, Newspaper, CalendarDays, CheckCircle2, FileText, Tag } from 'lucide-react'
 
 export default async function ContentsPage() {
   const contents = await getContents()
-  const filteredContents = contents?.filter(c => c.type === 'news' || c.type === 'event')
+  const allContents = contents?.filter((c) => c.type === 'news' || c.type === 'event') ?? []
+
+  const published  = allContents.filter((c) => c.is_published)
+  const drafts     = allContents.filter((c) => !c.is_published)
+  const newsItems  = allContents.filter((c) => c.type === 'news')
+  const eventItems = allContents.filter((c) => c.type === 'event')
 
   async function handleDelete(data: FormData) {
     'use server'
@@ -14,73 +19,139 @@ export default async function ContentsPage() {
     revalidatePath('/admin/contents')
   }
 
+  const kpis = [
+    { label: '総コンテンツ', value: allContents.length, icon: FileText, color: 'text-[#dfbd69]', bg: 'bg-[#dfbd6914]' },
+    { label: '公開中',       value: published.length,   icon: CheckCircle2, color: 'text-[#72b894]', bg: 'bg-[#72b89414]' },
+    { label: 'NEWS',         value: newsItems.length,   icon: Newspaper,    color: 'text-[#6ab0d4]', bg: 'bg-[#6ab0d414]' },
+    { label: 'EVENT',        value: eventItems.length,  icon: CalendarDays, color: 'text-[#a882d8]', bg: 'bg-[#a882d814]' },
+  ]
+
   return (
-    <div className="space-y-6 font-inter">
+    <div className="space-y-5 font-inter">
+
       {/* ── Page Header ── */}
-      <div className="flex flex-col xl:flex-row xl:items-center justify-between gap-4 py-2">
+      <div className="flex flex-col xl:flex-row xl:items-center justify-between gap-4
+                      rounded-[20px] border border-[#dfbd69]/22
+                      bg-[linear-gradient(135deg,#181510_0%,#131313_50%,#101010_100%)]
+                      px-6 py-5">
         <div className="flex flex-col gap-0.5">
-          <h1 className="text-[17px] font-semibold text-[#f4f1ea] tracking-[-0.31px]">ニュース管理</h1>
-          <p className="text-[11px] text-[#8a8478]">ニュース・イベント記事の管理と公開設定</p>
+          <h1 className="text-[17px] font-semibold tracking-[-0.31px] text-[#f4f1ea]">ニュース・イベント管理</h1>
+          <p className="text-[11px] text-[#8a8478]">公開サイトのニュース・イベント記事の管理と公開設定</p>
         </div>
         <Link
           href="/admin/contents/new"
-          className="flex items-center gap-1.5 px-4 py-2 rounded-[10px] text-[12px] font-semibold text-[#0b0b0d] transition-transform hover:scale-[1.02] whitespace-nowrap"
-          style={{ background: 'linear-gradient(90deg, rgba(223,189,105,1) 0%, rgba(146,111,52,1) 100%)' }}
+          className="inline-flex items-center gap-1.5 whitespace-nowrap rounded-[12px] px-5 py-2.5
+                     text-[13px] font-bold text-[#0b0b0d] transition-all hover:scale-[1.02] active:scale-[0.98]
+                     shadow-[0_4px_16px_rgba(223,189,105,0.2)]"
+          style={{ background: 'linear-gradient(90deg,rgba(223,189,105,1) 0%,rgba(146,111,52,1) 100%)' }}
         >
-          <Plus size={13} strokeWidth={3} />
+          <Plus size={14} strokeWidth={3} />
           新規投稿
         </Link>
       </div>
 
+      {/* ── KPI Grid ── */}
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+        {kpis.map((k) => (
+          <div
+            key={k.label}
+            className="bg-[#17181c] rounded-[18px] border border-[#ffffff0f] px-4 py-4 flex items-center gap-3"
+          >
+            <div className={`flex h-[36px] w-[36px] items-center justify-center rounded-[10px] ${k.bg} shrink-0`}>
+              <k.icon size={16} className={k.color} strokeWidth={1.8} />
+            </div>
+            <div>
+              <p className="text-[10px] text-[#5a5650] uppercase tracking-wider font-medium">{k.label}</p>
+              <p className={`text-[22px] font-bold leading-none mt-0.5 ${k.color}`}>{k.value}</p>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {/* ── Status Summary Bar ── */}
+      {allContents.length > 0 && (
+        <div className="flex items-center gap-3 rounded-[14px] border border-[#ffffff08] bg-[#17181c] px-5 py-3">
+          <div className="flex-1 h-[6px] rounded-full bg-[#ffffff08] overflow-hidden">
+            <div
+              className="h-full rounded-full"
+              style={{
+                width: `${Math.round((published.length / (allContents.length || 1)) * 100)}%`,
+                background: 'linear-gradient(90deg,#72b894,#4a9870)',
+              }}
+            />
+          </div>
+          <p className="text-[11px] font-medium text-[#8a8478] shrink-0">
+            公開率{' '}
+            <span className="text-[#72b894] font-bold">
+              {Math.round((published.length / (allContents.length || 1)) * 100)}%
+            </span>
+            <span className="ml-2 text-[#5a5650]">
+              ({published.length}/{allContents.length}件)
+            </span>
+          </p>
+          {drafts.length > 0 && (
+            <span className="rounded-full bg-[#ffffff08] px-2 py-0.5 text-[10px] font-bold text-[#8a8478]">
+              下書き {drafts.length}件
+            </span>
+          )}
+        </div>
+      )}
+
       {/* ── Content Table ── */}
       <div className="bg-[#17181c] rounded-[18px] border border-[#ffffff0f] overflow-hidden">
-        <div className="overflow-x-auto custom-scrollbar">
+        <div className="flex items-center gap-3 px-5 h-[52px] border-b border-[#ffffff08]">
+          <div className="flex h-[28px] w-[28px] items-center justify-center rounded-[7px] bg-[#dfbd6914]">
+            <Tag size={13} className="text-[#dfbd69]" />
+          </div>
+          <p className="text-[12px] font-semibold text-[#f4f1ea]">コンテンツ一覧</p>
+          <span className="ml-auto text-[10px] text-[#5a5650]">{allContents.length}件</span>
+        </div>
+
+        <div className="overflow-x-auto">
           <table className="w-full text-left">
             <thead>
               <tr className="bg-[#1c1d22] border-b border-[#ffffff08]">
-                <th className="px-5 py-3">
-                  <span className="text-[9px] font-bold tracking-[0.8px] text-[#5a5650] uppercase">種別</span>
-                </th>
-                <th className="px-5 py-3">
-                  <span className="text-[9px] font-bold tracking-[0.8px] text-[#5a5650] uppercase">タイトル</span>
-                </th>
-                <th className="px-5 py-3">
-                  <span className="text-[9px] font-bold tracking-[0.8px] text-[#5a5650] uppercase">日付</span>
-                </th>
-                <th className="px-5 py-3">
-                  <span className="text-[9px] font-bold tracking-[0.8px] text-[#5a5650] uppercase">ステータス</span>
-                </th>
-                <th className="px-5 py-3 text-right">
-                  <span className="text-[9px] font-bold tracking-[0.8px] text-[#5a5650] uppercase">操作</span>
-                </th>
+                {['種別', 'タイトル', '日付', 'ステータス', '操作'].map((h, i) => (
+                  <th key={i} className={`px-5 py-3 ${i === 4 ? 'text-right' : ''}`}>
+                    <span className="text-[9px] font-bold tracking-[0.8px] text-[#5a5650] uppercase">{h}</span>
+                  </th>
+                ))}
               </tr>
             </thead>
-            <tbody className="divide-y divide-[#ffffff08]">
-              {filteredContents?.map((content) => (
-                <tr key={content.id} className="hover:bg-[#ffffff04] transition-colors">
+            <tbody className="divide-y divide-[#ffffff06]">
+              {allContents.map((content) => (
+                <tr key={content.id} className="hover:bg-[#ffffff04] transition-colors group">
                   <td className="px-5 py-3.5">
-                    <span className={`text-[10px] font-bold px-2 py-0.5 rounded-full ${
-                      content.type === 'event'
-                        ? 'bg-[#a882d814] text-[#a882d8]'
-                        : 'bg-[#6ab0d414] text-[#6ab0d4]'
-                    }`}>
+                    <span
+                      className={`text-[10px] font-bold px-2 py-0.5 rounded-full ${
+                        content.type === 'event'
+                          ? 'bg-[#a882d814] text-[#a882d8]'
+                          : 'bg-[#6ab0d414] text-[#6ab0d4]'
+                      }`}
+                    >
                       {content.type === 'event' ? 'EVENT' : 'NEWS'}
                     </span>
                   </td>
-                  <td className="px-5 py-3.5">
-                    <p className="text-[12px] font-semibold text-[#c7c0b2] line-clamp-1">{content.title}</p>
+                  <td className="px-5 py-3.5 max-w-[260px]">
+                    <p className="truncate text-[12px] font-semibold text-[#c7c0b2] group-hover:text-[#f4f1ea] transition-colors">
+                      {content.title}
+                    </p>
                   </td>
                   <td className="px-5 py-3.5">
                     <span className="text-[11px] text-[#5a5650]">
-                      {content.content_date ? content.content_date.slice(0, 10).replace(/-/g, '/') : '–'}
+                      {content.content_date
+                        ? content.content_date.slice(0, 10).replace(/-/g, '/')
+                        : '–'}
                     </span>
                   </td>
                   <td className="px-5 py-3.5">
-                    <span className={`text-[10px] font-bold px-2 py-0.5 rounded-full ${
-                      content.is_published
-                        ? 'bg-[#72b89414] text-[#72b894]'
-                        : 'bg-[#ffffff08] text-[#5a5650]'
-                    }`}>
+                    <span
+                      className={`text-[10px] font-bold px-2 py-0.5 rounded-full ${
+                        content.is_published
+                          ? 'bg-[#72b89414] text-[#72b894]'
+                          : 'bg-[#ffffff08] text-[#5a5650]'
+                      }`}
+                    >
                       {content.is_published ? '公開中' : '下書き'}
                     </span>
                   </td>
@@ -88,7 +159,8 @@ export default async function ContentsPage() {
                     <div className="flex justify-end items-center gap-1">
                       <Link
                         href={`/admin/contents/${content.id}/edit`}
-                        className="p-2 text-[#5a5650] hover:text-[#c7c0b2] transition-colors rounded-[8px] hover:bg-[#ffffff08]"
+                        className="rounded-[8px] p-1.5 text-[#5a5650] transition-colors hover:bg-[#dfbd6914] hover:text-[#dfbd69]"
+                        title="編集"
                       >
                         <Edit2 size={14} />
                       </Link>
@@ -96,7 +168,8 @@ export default async function ContentsPage() {
                         <input type="hidden" name="id" value={content.id} />
                         <button
                           type="submit"
-                          className="p-2 text-[#5a5650] hover:text-[#d4785a] transition-colors rounded-[8px] hover:bg-[#d4785a10]"
+                          className="rounded-[8px] p-1.5 text-[#5a5650] transition-colors hover:bg-[#d4785a14] hover:text-[#d4785a]"
+                          title="削除"
                         >
                           <Trash2 size={14} />
                         </button>
@@ -105,11 +178,19 @@ export default async function ContentsPage() {
                   </td>
                 </tr>
               ))}
-              {(!filteredContents || filteredContents.length === 0) && (
+
+              {allContents.length === 0 && (
                 <tr>
-                  <td colSpan={5} className="px-5 py-14 text-center">
+                  <td colSpan={5} className="px-5 py-16 text-center">
                     <Newspaper size={24} className="mx-auto mb-3 text-[#5a5650]" />
-                    <p className="text-[12px] text-[#5a5650] italic">記事が登録されていません</p>
+                    <p className="text-[12px] text-[#5a5650] italic mb-4">記事が登録されていません</p>
+                    <Link
+                      href="/admin/contents/new"
+                      className="inline-flex items-center gap-1.5 text-[12px] font-bold text-[#dfbd69] hover:underline"
+                    >
+                      <Plus size={13} />
+                      最初の記事を投稿する
+                    </Link>
                   </td>
                 </tr>
               )}
@@ -117,6 +198,7 @@ export default async function ContentsPage() {
           </table>
         </div>
       </div>
+
     </div>
   )
 }

--- a/app/admin/(protected)/design/page.tsx
+++ b/app/admin/(protected)/design/page.tsx
@@ -1,80 +1,199 @@
 import Link from 'next/link'
-import { ImageIcon, Grid3X3, Palette, ChevronRight, Layers } from 'lucide-react'
+import { createClient } from '@/lib/supabase/server'
+import {
+  ImageIcon,
+  Grid3X3,
+  Palette,
+  ChevronRight,
+  Layers,
+  Sparkles,
+  LayoutTemplate,
+  Plus,
+  Eye,
+} from 'lucide-react'
 
-export default function DesignPage() {
+export const dynamic = 'force-dynamic'
+
+export default async function DesignPage() {
+  const supabase = await createClient()
+
+  const [heroResult, galleryResult] = await Promise.all([
+    supabase.from('contents').select('id, is_published', { count: 'exact' }).eq('type', 'hero'),
+    supabase.from('contents').select('id, is_published', { count: 'exact' }).eq('type', 'gallery'),
+  ])
+
+  const heroItems    = heroResult.data ?? []
+  const galleryItems = galleryResult.data ?? []
+  const heroCount    = heroItems.length
+  const galleryCount = galleryItems.length
+  const heroPublished    = heroItems.filter((h) => h.is_published).length
+  const galleryPublished = galleryItems.filter((g) => g.is_published).length
+
   const sections = [
     {
-      href:     '/admin/hero',
-      icon:     ImageIcon,
-      title:    'ヒーロー管理',
-      sub:      'トップページのヒーロービジュアルと表示テキストを管理します',
-      badge:    null,
-      iconBg:   'bg-[#dfbd691a]',
-      iconColor:'text-[#dfbd69]',
+      href:       '/admin/hero',
+      icon:       ImageIcon,
+      addHref:    '/admin/hero/new',
+      title:      'ヒーロー管理',
+      sub:        'トップページのヒーロービジュアルと表示テキストを管理します',
+      iconBg:     'bg-[#dfbd6914]',
+      iconColor:  'text-[#dfbd69]',
+      count:      heroCount,
+      published:  heroPublished,
+      countLabel: 'スライド',
     },
     {
-      href:     '/admin/gallery',
-      icon:     Grid3X3,
-      title:    'ギャラリー管理',
-      sub:      'サイトのギャラリーセクションに表示する画像を管理します',
-      badge:    null,
-      iconBg:   'bg-[#6ab0d414]',
-      iconColor:'text-[#6ab0d4]',
+      href:       '/admin/gallery',
+      icon:       Grid3X3,
+      addHref:    '/admin/gallery/new',
+      title:      'ギャラリー管理',
+      sub:        'サイトのギャラリーセクションに表示する画像を管理します',
+      iconBg:     'bg-[#6ab0d414]',
+      iconColor:  'text-[#6ab0d4]',
+      count:      galleryCount,
+      published:  galleryPublished,
+      countLabel: '画像',
     },
     {
-      href:     '/admin/settings',
-      icon:     Palette,
-      title:    '設定',
-      sub:      '店舗名・基本情報・SNSリンク・カラー設定など基本設定を管理します',
-      badge:    null,
-      iconBg:   'bg-[#a882d814]',
-      iconColor:'text-[#a882d8]',
+      href:       '/admin/settings',
+      icon:       Palette,
+      addHref:    null,
+      title:      '設定',
+      sub:        '店舗名・基本情報・SNS・カラー・LINE通知などを管理します',
+      iconBg:     'bg-[#a882d814]',
+      iconColor:  'text-[#a882d8]',
+      count:      null,
+      published:  null,
+      countLabel: null,
     },
   ]
 
   return (
-    <div className="space-y-6 font-inter">
+    <div className="space-y-5 font-inter">
+
       {/* ── Page Header ── */}
       <div className="flex flex-col gap-0.5 py-2">
-        <h1 className="text-[17px] font-semibold text-[#f4f1ea] tracking-[-0.31px]">デザイン管理</h1>
-        <p className="text-[11px] text-[#8a8478]">サイトの視覚的な要素とコンテンツを管理します</p>
+        <h1 className="text-[17px] font-semibold tracking-[-0.31px] text-[#f4f1ea]">デザイン管理</h1>
+        <p className="text-[11px] text-[#8a8478]">サイトの視覚的要素・コンテンツ・基本設定をまとめて管理します</p>
       </div>
 
       {/* ── Section Cards ── */}
-      <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
         {sections.map((s) => (
-          <Link
+          <div
             key={s.href}
-            href={s.href}
-            className="group bg-[#17181c] rounded-[18px] border border-[#ffffff0f] p-6 flex flex-col gap-4 hover:border-[#ffffff18] hover:bg-[#1c1d22] transition-all"
+            className="group bg-[#17181c] rounded-[20px] border border-[#ffffff0f] p-6 flex flex-col gap-5
+                       hover:border-[#ffffff18] hover:bg-[#1c1d22] transition-all"
           >
             <div className="flex items-start justify-between">
-              <div className={`w-[44px] h-[44px] flex items-center justify-center rounded-[12px] ${s.iconBg}`}>
+              <div className={`flex h-[44px] w-[44px] items-center justify-center rounded-[12px] ${s.iconBg}`}>
                 <s.icon size={20} className={s.iconColor} strokeWidth={1.8} />
               </div>
-              <ChevronRight size={16} className="text-[#5a5650] group-hover:text-[#8a8478] transition-colors mt-1" />
+              {s.count !== null && (
+                <div className="text-right">
+                  <p className="text-[22px] font-bold leading-none text-[#f4f1ea]">{s.count}</p>
+                  <p className="text-[10px] text-[#5a5650] mt-0.5">{s.countLabel}</p>
+                </div>
+              )}
             </div>
+
             <div>
               <p className="text-[14px] font-semibold text-[#f4f1ea] mb-1">{s.title}</p>
               <p className="text-[11px] text-[#8a8478] leading-relaxed">{s.sub}</p>
             </div>
-          </Link>
+
+            {/* Published bar */}
+            {s.count !== null && s.count > 0 && (
+              <div className="space-y-1.5">
+                <div className="flex items-center justify-between text-[10px]">
+                  <span className="text-[#5a5650]">公開中</span>
+                  <span className="text-[#72b894] font-bold">{s.published}/{s.count}</span>
+                </div>
+                <div className="h-[3px] w-full rounded-full bg-[#ffffff08] overflow-hidden">
+                  <div
+                    className="h-full rounded-full bg-[#72b894]"
+                    style={{ width: `${Math.round(((s.published ?? 0) / (s.count || 1)) * 100)}%` }}
+                  />
+                </div>
+              </div>
+            )}
+
+            <div className="flex items-center gap-2 mt-auto pt-1 border-t border-[#ffffff06]">
+              <Link
+                href={s.href}
+                className="flex flex-1 items-center justify-center gap-1.5 rounded-[10px] border border-[#ffffff0f]
+                           px-3 py-2 text-[11px] font-medium text-[#c7c0b2] transition-colors hover:border-[#ffffff18] hover:text-[#f4f1ea]"
+              >
+                <Eye size={12} />
+                管理する
+              </Link>
+              {s.addHref && (
+                <Link
+                  href={s.addHref}
+                  className="flex items-center justify-center h-[34px] w-[34px] rounded-[10px] shrink-0 transition-colors"
+                  style={{ background: 'linear-gradient(90deg,rgba(223,189,105,0.15),rgba(146,111,52,0.15))', border: '1px solid rgba(223,189,105,0.2)' }}
+                  title="新規追加"
+                >
+                  <Plus size={13} className="text-[#dfbd69]" />
+                </Link>
+              )}
+            </div>
+          </div>
         ))}
       </div>
 
-      {/* ── Info ── */}
+      {/* ── Design System Info ── */}
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        {/* Animation & UX */}
+        <div className="bg-[#17181c] rounded-[18px] border border-[#ffffff0f] p-5 flex items-start gap-4">
+          <div className="flex h-[36px] w-[36px] items-center justify-center rounded-[10px] bg-[#dfbd6914] shrink-0 mt-0.5">
+            <Sparkles size={16} className="text-[#dfbd69]" />
+          </div>
+          <div>
+            <p className="text-[12px] font-semibold text-[#c7c0b2] mb-1.5">アニメーション・演出</p>
+            <p className="text-[11px] text-[#8a8478] leading-relaxed mb-3">
+              ヒーロースライドのトランジション、ムード設定（今夜の演出）、VIP対応フラグなどの動的設定は「設定」ページから変更できます。
+            </p>
+            <Link
+              href="/admin/animation-preview"
+              className="inline-flex items-center gap-1 text-[11px] font-medium text-[#dfbd69] hover:underline"
+            >
+              アニメーションプレビュー
+              <ChevronRight size={11} />
+            </Link>
+          </div>
+        </div>
+
+        {/* Layout System */}
+        <div className="bg-[#17181c] rounded-[18px] border border-[#ffffff0f] p-5 flex items-start gap-4">
+          <div className="flex h-[36px] w-[36px] items-center justify-center rounded-[10px] bg-[#6ab0d414] shrink-0 mt-0.5">
+            <LayoutTemplate size={16} className="text-[#6ab0d4]" />
+          </div>
+          <div>
+            <p className="text-[12px] font-semibold text-[#c7c0b2] mb-1.5">レイアウトシステム</p>
+            <p className="text-[11px] text-[#8a8478] leading-relaxed">
+              ヒーロー・ギャラリーは画像とテキストの追加・並び替え・削除に対応。
+              各セクションの表示/非表示は公開ステータスで制御されます。
+            </p>
+          </div>
+        </div>
+      </div>
+
+      {/* ── Design System Note ── */}
       <div className="bg-[#17181c] rounded-[18px] border border-[#ffffff0f] p-5 flex items-start gap-3">
-        <div className="w-[30px] h-[30px] flex items-center justify-center bg-[#dfbd691a] rounded-[8px] shrink-0 mt-0.5">
+        <div className="flex h-[30px] w-[30px] items-center justify-center rounded-[8px] bg-[#dfbd6914] shrink-0 mt-0.5">
           <Layers size={14} className="text-[#dfbd69]" />
         </div>
         <div>
           <p className="text-[12px] font-semibold text-[#c7c0b2] mb-1">デザインシステムについて</p>
           <p className="text-[11px] text-[#8a8478] leading-relaxed">
-            ヒーロー・ギャラリーは画像とテキストの追加・並び替え・削除に対応しています。
-            カラーや基本情報などの詳細設定は設定ページから変更できます。
+            本サイトは Tailwind CSS v4 + Framer Motion v12 + GSAP3 + Three.js で構築されています。
+            カラー・テキスト・アニメーション設定は設定ページから変更、
+            ビジュアル素材はヒーロー管理・ギャラリー管理から編集できます。
           </p>
         </div>
       </div>
+
     </div>
   )
 }

--- a/app/admin/(protected)/shifts/page.tsx
+++ b/app/admin/(protected)/shifts/page.tsx
@@ -1,5 +1,7 @@
 import { getWeeklySchedules, getMonthlySchedules } from '@/lib/actions/schedules'
 import { ShiftManager } from '@/components/features/admin/ShiftManager'
+import { CalendarDays, Grid3X3, ChevronRight } from 'lucide-react'
+import Link from 'next/link'
 
 export default async function ShiftsPage({
   searchParams,
@@ -8,23 +10,97 @@ export default async function ShiftsPage({
 }) {
   const targetDate = searchParams.date ? new Date(searchParams.date) : new Date()
   const viewType = searchParams.view === 'month' ? 'month' : 'week'
-  const data = viewType === 'month' 
+  const data = viewType === 'month'
     ? await getMonthlySchedules(targetDate)
     : await getWeeklySchedules(targetDate)
 
+  const castCount = data.casts?.length ?? 0
+
   return (
-    <div className="space-y-6">
-      <div className="flex justify-between items-center">
-        <div>
-          <h1 className="text-2xl font-serif tracking-widest text-[#171717]">Shifts Management</h1>
-          <p className="text-sm text-gray-500 mt-2">出勤スケジュールの登録と管理（チェックボックス一括更新）</p>
+    <div className="space-y-5 font-inter">
+
+      {/* ── Page Header ── */}
+      <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4
+                      rounded-[20px] border border-[#dfbd69]/22
+                      bg-[linear-gradient(135deg,#181510_0%,#131313_50%,#101010_100%)]
+                      px-6 py-5">
+        <div className="flex items-center gap-4">
+          <div className="flex h-[44px] w-[44px] items-center justify-center rounded-[12px] bg-[#dfbd6914] shrink-0">
+            <CalendarDays size={20} className="text-[#dfbd69]" strokeWidth={1.8} />
+          </div>
+          <div>
+            <h1 className="text-[17px] font-semibold tracking-[-0.31px] text-[#f4f1ea]">
+              シフト管理
+            </h1>
+            <p className="mt-0.5 text-[11px] text-[#8a8478]">
+              出勤スケジュールの登録・一括更新
+              {castCount > 0 && (
+                <span className="ml-2 font-medium text-[#dfbd69]">{castCount}名</span>
+              )}
+            </p>
+          </div>
+        </div>
+
+        {/* View Toggle */}
+        <div className="flex items-center gap-1 rounded-[10px] border border-[#ffffff0f] bg-[#1c1d22] p-1">
+          {[
+            { id: 'week',  label: '週次', icon: CalendarDays },
+            { id: 'month', label: '月次', icon: Grid3X3 },
+          ].map(({ id, label, icon: Icon }) => {
+            const isActive = viewType === id
+            return (
+              <Link
+                key={id}
+                href={`/admin/shifts?view=${id}`}
+                className={`flex items-center gap-1.5 rounded-[7px] px-3 py-1.5 text-[12px] font-medium transition-colors ${
+                  isActive
+                    ? 'bg-[#dfbd6920] text-[#dfbd69]'
+                    : 'text-[#5a5650] hover:text-[#8a8478]'
+                }`}
+              >
+                <Icon size={12} />
+                {label}
+              </Link>
+            )
+          })}
         </div>
       </div>
 
+      {/* ── Quick Nav ── */}
+      <div className="grid grid-cols-2 gap-3">
+        {[
+          { href: '/admin/shift-requests', label: '出勤調整・承認', sub: '未承認のシフト申請を確認', dot: true },
+          { href: '/admin/monthly-shifts', label: 'シフト印刷表',  sub: '月次シフト一覧・エクスポート', dot: false },
+        ].map((item) => (
+          <Link
+            key={item.href}
+            href={item.href}
+            className="group flex items-center gap-3 rounded-[14px] border border-[#ffffff0f] bg-[#17181c]
+                       px-4 py-3 transition-all hover:bg-[#1c1d22] hover:border-[#dfbd69]/20"
+          >
+            <div className="min-w-0 flex-1">
+              <div className="flex items-center gap-1.5">
+                {item.dot && <span className="h-1.5 w-1.5 rounded-full bg-[#dfbd69] shrink-0" />}
+                <p className="text-[12px] font-semibold text-[#c7c0b2] truncate">{item.label}</p>
+              </div>
+              <p className="mt-0.5 text-[10px] text-[#5a5650]">{item.sub}</p>
+            </div>
+            <ChevronRight size={14} className="text-[#5a5650] group-hover:text-[#dfbd69] transition-colors shrink-0" />
+          </Link>
+        ))}
+      </div>
+
+      {/* ── Shift Manager ── */}
       <ShiftManager
-        initialData={{ casts: data.casts, shifts: data.schedules, dates: data.dates, dailyStaffing: data.dailyStaffing }}
+        initialData={{
+          casts: data.casts,
+          shifts: data.schedules,
+          dates: data.dates,
+          dailyStaffing: data.dailyStaffing,
+        }}
         viewType={viewType}
       />
+
     </div>
   )
 }


### PR DESCRIPTION
…n dashboard pages

- Add フリガナ (nameKana) input to /cast/register and /cast/m/register fixing 「想定外エラー: すべての項目を入力してください」 caused by missing nameKana field required by castRegister server action validation

- Redesign cast profile page: add PV stats, ranking, recent posts grid, quick links; parallel fetch getCastPVStats + getMyCastPosts

- Fix admin/shifts page header color bug (#171717 → #f4f1ea) + dark theme header with quick nav to shift-requests and monthly-shifts

- Expand admin/analytics page: add post PV ranking (getAdminPostRankings), bar chart visualisation, two-column layout

- Enhance admin/contents page: add 4-KPI grid (total/published/NEWS/EVENT)
  + publication rate progress bar

- Enrich admin/design page: fetch hero/gallery counts from DB, show published ratios, add animation and layout system info sections