### PR TITLE
fix(admin): sync casts.is_today on manual attendance override

### DIFF
--- a/lib/actions/today.ts
+++ b/lib/actions/today.ts
@@ -987,7 +987,32 @@ export async function updateDailyCastAttendance(input: {
     return { success: false, error: error.message }
   }
 
+  // Sync casts.is_today so the public "本日の出勤キャスト" reflects the override
+  let isToday: boolean
+  if (input.status === 'working') {
+    isToday = true
+  } else if (input.status === 'absent') {
+    isToday = false
+  } else {
+    // undecided: revert to approved-shift-based value
+    const serviceSupabase = createServiceClient()
+    const { data: schedule } = await serviceSupabase
+      .from('cast_schedules')
+      .select('id')
+      .eq('cast_id', input.castId)
+      .eq('work_date', today)
+      .maybeSingle()
+    isToday = !!schedule
+  }
+
+  await supabase
+    .from('casts')
+    .update({ is_today: isToday })
+    .eq('id', input.castId)
+
   revalidatePath('/admin/dashboard')
   revalidatePath('/admin/today')
+  revalidatePath('/cast')
+  revalidatePath('/')
   return { success: true }
 }


### PR DESCRIPTION
## Summary

- `updateDailyCastAttendance()` が `daily_cast_attendance` に書き込んだ後、`casts.is_today` を更新するよう修正
- `revalidatePath('/cast')` と `revalidatePath('/')` を追加し、公開サイトへ即時反映
- `undecided`（リセット）時は `cast_schedules` を確認して承認済みシフトベースの値に戻す

## 変更理由

管理者が `/admin/dashboard` の「本日の出勤キャスト」パネルで 出勤/欠勤 を変更しても、公開サイトの「本日出勤」バッジに反映されなかった。`casts.is_today`（公開サイトの判定ソース）が更新されていなかったため。

## 変更ファイル

- `lib/actions/today.ts` — `updateDailyCastAttendance()` のみ

## スコープ外（変更なし）

- キャスト側の19:00提出締切制限（`submitCheckin`）
- DBスキーマ
- UI コンポーネント

## 本番反映前の注意

- `cast-auth.ts:438` に既存のビルドエラーあり（本PRとは無関係）。先に修正が必要。
- `casts.is_today` の日跨ぎリセット機構は別途検討が必要（現状もリスクは既存）。

## Test plan

- [ ] `/admin/dashboard` → 出勤キャストパネルで「出勤」ボタンをクリック
- [ ] 公開サイト `/cast` を開き「本日出勤」バッジが表示されることを確認
- [ ] 「欠勤」ボタンでバッジが消えることを確認
- [ ] 「—」でリセット後、承認済みシフトがある場合は「本日出勤」が維持されることを確認
- [ ] キャスト側（19:00以降）は `submitCheckin` が変更不可のままであることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)