### PR TITLE
fix(admin): restore mobile sidebar slide-in animation

### DIFF
--- a/components/layouts/AdminLayout.tsx
+++ b/components/layouts/AdminLayout.tsx
@@ -331,14 +331,14 @@ function AdminLayoutInner({
           aria-hidden
         />
       ) : null}
-      {mobileOpen ? (
-        <aside
-          onClickCapture={handleMobileSidebarClickCapture}
-          className="fixed top-0 left-0 h-full w-[260px] z-50 md:hidden transition-transform duration-300 ease-out translate-x-0"
-        >
-          {renderSidebarContent()}
-        </aside>
-      ) : null}
+      <aside
+        onClickCapture={handleMobileSidebarClickCapture}
+        className={`fixed top-0 left-0 h-full w-[260px] z-50 md:hidden transition-transform duration-300 ease-out ${
+          mobileOpen ? 'translate-x-0' : '-translate-x-full'
+        }`}
+      >
+        {renderSidebarContent()}
+      </aside>
 
       {/* Mobile Bottom Tab */}
       <nav className={`fixed bottom-0 left-0 right-0 z-30 md:hidden border-t pb-safe font-inter ${T.mobileTab}`}>


### PR DESCRIPTION
## Summary
- モバイルサイドバーがハンバーガーボタンを押しても開かない問題を修正
- 原因: `84914a1` で条件付きマウント/アンマウント方式に変更されたため、CSSトランジションが動作しなかった
- 修正: 常にDOMに存在させ、`-translate-x-full` ↔ `translate-x-0` のCSSトランスフォームで開閉するパターンに戻した

## Test plan
- [ ] モバイル幅でハンバーガーボタンをタップ → サイドバーがスライドインで開くことを確認
- [ ] オーバーレイをタップ → サイドバーが閉じることを確認
- [ ] ナビゲーションリンクをタップ → サイドバーが閉じてページ遷移することを確認
- [ ] デスクトップ幅では変化なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)