### PR TITLE
style(admin): align settings design page with admin UI system

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,112 +1,337 @@
-# Animo Design Constitution
+# Club Animo — Admin / Cast UI design source
 
-This file is the root design authority for the Animo project.
-It defines brand principles, surface hierarchy, and points to detailed design rules.
+**Scope:** Protected admin and cast surfaces only. **Out of scope:** public marketing site (separate labels, separate time rules).
 
----
+**Stack rule:** Figma is the visual reference for composition. **This file** is the authority for operational structure, tokens, time semantics, approval layout, and prohibited patterns. If Figma and this file conflict on **operational** rules, this file wins; if **purely visual** (color step, shadow), Figma wins.
 
-## Visual Source of Truth
-
-**Figma** is the single source of truth for all visual decisions.
-
-- File: `Animo` (Figma team project)
-- Desktop Admin: `Animo Dashboard` page
-- Mobile Admin: `Animo Dashboard-Mobile` page
-- Cast Dashboard: `Animo Cast Dashboard` page
-- Public Site: `Animo Login Desktop` page
-
-When Figma and code diverge, Figma wins.
-When Figma is ambiguous, this document and `docs/design/` win.
-When neither covers a case, escalate — do not invent.
+**Figma pages (names only; no separate doc section):** `Animo` project — `Animo Dashboard` (desktop admin), `Animo Dashboard-Mobile` (mobile admin), `Animo Cast Dashboard` (cast), public surfaces use separate frames (e.g. `Animo Login Desktop`); do not copy internal operation labels into public comps.
 
 ---
 
-## Brand Principles
+## 1. Design purpose
 
-1. **Black is the main surface.** Admin interfaces use dark surfaces (#0a0a0a – #1a1a1a).
-2. **Gold is a controlled accent.** Used for values, active states, and thin bezels — never for large fills or thick ornamental frames.
-3. **Quiet luxury over decoration.** Prefer subtle depth (layered shadows, micro-gradients) over loud visual effects.
-4. **Information density over empty space.** Every pixel should serve operational clarity. Avoid oversized empty cards.
-5. **Shared components, not one-off visuals.** Every new surface must use an existing component family or formally extend one.
-
----
-
-## Surface Hierarchy (Admin)
-
-| Layer | Role | Example |
-|-------|------|---------|
-| Page background | Deepest black | `#0b0b0d` |
-| Card surface | Dark gloss panel | `.card-premium-skin__surface` |
-| Gold bezel | Thin metallic edge (3–7px) | `.card-premium-skin::before/::after` |
-| Content | Text, icons, badges | z-index: 1, always on top |
-
-The `.card-premium-skin` class in `globals.css` is the canonical shared surface for all admin panels and cards.
-KPI cards use a specialized variant (`.kpi-card`) with a 4-layer stack: base → gold-back → gold-accent → surface.
+| Surface | Job |
+|--------|-----|
+| **Admin** | Run daily operations: attendance, shifts, approvals, customers, comms. |
+| **Cast** | Fast submit, confirm state, and communicate; task-first, mobile. |
+| **Public** | Never inherit internal operation labels, staff-only routes, or admin time copy. |
 
 ---
 
-## Color System (Admin Surfaces)
+## 2. Core principles
 
-| Token | Hex | Usage |
-|-------|-----|-------|
-| Surface black | `#0a0a0a` – `#1a1a1a` | Card backgrounds |
-| Foundation | `#393939` | Deepest card layer |
-| Text primary | `#f4f1ea` | Headings, values |
-| Text secondary | `#c7c0b2` – `#cbc3b3` | Body text |
-| Text muted | `#8a8478` | Labels, subtitles |
-| Text dim | `#5a5650` | Table headers, placeholders |
-| Gold accent | `#dfbd69` | Icons, active states |
-| Gold gradient | `#D1B25E → #8F7130` | KPI values |
-| Success | `#72b894` / bg `#50a064` | Confirmed states |
-| Warning | `#c8884d` / bg `#c88232` | Pending, late states |
-| Danger | `#d4785a` / bg `#c8643c` | Alerts, errors |
+- Sales and operation first; no decoration without function.
+- No mock, placeholder, or fake operational UI.
+- Every button, card, counter, and badge must map to **real data**, **server action**, or **route** (or be removed).
+- **Mobile-first** for cast and for admin on-the-floor screens.
+- **Desktop admin:** use width efficiently; avoid cramped type; fixed shell + scrollable main (see §4).
+- **Information > decoration;** avoid empty visual mass (see §9, §12).
+- Prefer subtle depth (shadows, micro-gradients) only when they clarify hierarchy — not loud effects or faux-operational chrome.
 
 ---
 
-## Typography (Admin)
+## 3. Color system (black / gold Animo)
 
-| Role | Family | Size | Weight |
-|------|--------|------|--------|
-| Page title | `font-sans` (Noto Sans JP) | 22px | 700 |
-| Section title | `font-sans` | 17px | 700 |
-| Card title | `font-sans` | 13px | 600–700 |
-| KPI value | `font-sans` (Inter) | 30px | 700 |
-| Body | `font-sans` | 13–14px | 500 |
-| Label | `font-sans` | 11–12px | 500–700 |
-| Table header | `font-sans` | 9–10px | 700 |
-| Badge | `font-sans` | 10px | 700 |
+Use existing design tokens / `globals.css` where they exist; values below are the **contract** for new work.
 
----
+| Role | Value / note |
+|------|----------------|
+| Page background | Deepest black (e.g. `#0b0b0d` / foundation stack) — fixed under scroll |
+| Card background | Dark panel (e.g. `#0a0a0a`–`#1a1a1a` / `.card-premium-skin` surface) |
+| Border | Subtle light edge (e.g. `rgba(255,255,255,0.06)` on dark) |
+| Gold accent | `#dfbd69` / `rgba(223,189,105,1)` — active, focus, primary emphasis |
+| Warning / risk | Amber/orange family for pending / late (e.g. `#c8884d`) |
+| Danger / reject | Red family for destructive / error (e.g. `#d4785a`) |
+| Muted text | `#8a8478` — labels, secondary nav section titles |
+| Primary text | `#f4f1ea` / high-contrast on dark — titles, values |
 
-## Non-Negotiable Rules
+**Gold usage:** accent and thin bezels only — no large gold fills. **Bezel thickness:** 3–7px; larger gold frames are invalid.
 
-1. **No thick gold frames.** Gold bezels are 3–7px. Anything larger is a bug.
-2. **No oversized empty cards.** If a card has less than 3 data points, it is too large.
-3. **No one-off status colors.** Use `StatusBadge` patterns: success/warning/danger/neutral/accent.
-4. **No custom scrollbars without `.custom-scrollbar`.** Scrollable regions use the shared class.
-5. **No inline font-family.** Always use Tailwind `font-sans` / `font-serif` / `font-heading`.
-6. **Mobile minimum font: 12px.** Enforced via `globals.css` media query.
-7. **Border radius: 18px for cards, 10–12px for buttons, 6–8px for badges.**
+**Admin surface stack (in code):** shared card surface = `.card-premium-skin` in `app/globals.css` (gold bezel via `::before` / `::after`); KPI cards = `.kpi-card` (4-layer: base → gold-back → gold-accent → surface). Content (text, icons, badges) sits above decorative layers (z-index on content).
 
 ---
 
-## Detailed Design Documents
+## 4. Layout system
 
-| File | Scope |
-|------|-------|
-| [shared-foundation.md](docs/design/shared-foundation.md) | Color, surface, border, radius, depth, typography, shared components, status pills, buttons, tables |
-| [mobile-admin.md](docs/design/mobile-admin.md) | Mobile admin layout, compact KPIs, urgent action blocks, operational lists, bottom nav, anti-patterns |
+### Admin — desktop
 
-Future files (not yet created):
-- `docs/design/mobile-cast.md` — Cast-side mobile interface
-- `docs/design/public-site.md` — Public-facing website
+- **Fixed sidebar** (width §11).
+- **Fixed page background** (main content scrolls inside the shell).
+- **Main content:** vertical scroll; max width **none** (full remaining width).
+- **Approval hub / multi-queue:** may use **independent vertical scroll per lane** (§7).
+- **Page padding:** 24px (§11).
+
+### Admin — mobile
+
+- Single column; **cards only**; **no horizontal tables.**
+- Bottom nav or drawer — **must not cover primary submit / save** (content bottom padding §11).
+
+### Cast — mobile
+
+- Smartphone-first; **large tap targets** (min 44px); task order = priority order.
 
 ---
 
-## Implementation Notes
+## 5. Component rules
 
-- Desktop admin is the parent visual system.
-- Mobile admin is the compressed operational surface using the same design language.
-- All admin components live in `components/features/admin/`.
-- The canonical CSS surface is defined in `app/globals.css` (`.card-premium-skin` family).
-- Do not duplicate design rules into `CLAUDE.md` or `AGENTS.md`.
+| Component | Rule |
+|-----------|------|
+| **Cards** | One primary action or summary per card where applicable; use §11 radius/padding/min heights. |
+| **Buttons** | Heights §11; every button wired to action or `href`. |
+| **Badges** | StatusBadge / semantic colors; no invented labels. |
+| **Section headers** | One baseline per row; typography §11. |
+| **Form inputs** | Heights §11; labels associated; no dummy fields. |
+| **Scroll areas** | Prefer single page scroll; nested scroll only where specified (lanes). Scrollable regions must use the shared `.custom-scrollbar` class (no one-off scrollbar styling). |
+| **Empty states** | Explain why empty + next action (route), not “lorem” blocks. |
+| **Approval cards** | Min height §11; full width of lane; actions call real mutations. |
+
+---
+
+## 6. Time display rules
+
+| Context | Rule |
+|---------|------|
+| **Protected admin / cast** | Operating band copy: **`19:00〜2:00`** (next calendar day). |
+| **Time selectors** | Options: **`19:00` … `23:45`**, then **`0:00` … `2:00`** (use `lib/operation-hours` / `getOperationTimeOptions` — never hand-roll forbidden strings). |
+| **Forbidden** | Never show **`24:00` / `25:00` / `26:00`** in any UI string or option. |
+| **Public site** | Hours copy: **`21:00〜LAST` only** — not the internal 19:00 band. |
+
+---
+
+## 7. Approval page design
+
+### Desktop — 3 fixed lanes (equal logical width; grid §12)
+
+1. **本日の出勤承認** + **来店予定承認** (single lane, stacked sections or tabs — same lane scroll).
+2. **シフト承認**
+3. **その他承認**（ブログ・写真）
+
+- Fixed background; **each lane** scrolls independently; **cards only**; lane metrics §11.
+- Lane header height **44px**.
+
+### Mobile — single column order
+
+1. 本日の出勤承認  
+2. 来店予定承認  
+3. シフト承認  
+4. ブログ承認  
+5. 写真承認  
+
+---
+
+## 8. Dashboard vs deep operations
+
+- **`/admin/dashboard`:** decision + **entry points** only (links/cards to real queues).
+- **`/admin/today`:** **deep operation** screen (phase controls, time selector, operational density).
+- **Do not** duplicate `/admin/today` controls on the dashboard unless explicitly approved and sourced from the same data.
+
+---
+
+## 9. Forbidden patterns
+
+- Fake counters; placeholder cards; dead buttons; horizontal scroll tables on mobile.
+- Oversized cards that contain fewer than three meaningful data points (violates density rules in §12).
+- Charts without axis labels / unexplained metrics.
+- Hardcoded **24/25/26** time labels.
+- **UI-only** approval buttons (no mutation / no route).
+- Internal operation wording on **public** routes.
+- Thick ornamental gold frames (bezels beyond §3 thickness band); one-off status colors outside `StatusBadge` semantics (success / warning / danger / neutral / accent).
+- **Typography:** no arbitrary `font-family` inline — use Tailwind `font-sans` / `font-serif` / `font-heading` (see §11 scale).
+
+---
+
+## 10. Implementation checklist
+
+### Read before UI work
+
+- This file: **`DESIGN.md`**
+- **`CURRENT_STATE.md`** + latest 2 × `PLANS.md` + `daily_log.md`
+- **`AGENTS.md`** (repo constraints)
+- When touching time UI: **`lib/operation-hours.ts`**, **`OperationTimeSelect`**
+
+### Files / areas that must align with this doc
+
+- `components/layouts/AdminLayout.tsx` — shell, sidebar, scroll.
+- `app/admin/(protected)/**` — especially `dashboard`, `today`, `approvals`, `shift-requests`.
+- `components/features/admin/**`
+- `app/cast/**` and cast feature components.
+
+### Validation before commit
+
+- `pnpm lint` (0 new errors)
+- `pnpm build` when shared types/layout touched
+- Targeted `pnpm exec eslint "<paths>"` for changed files
+- Grep: no `24:00`|`25:00`|`26:00` in changed UI strings
+
+### Additional references (supplementary to §1–12)
+
+- [docs/design/shared-foundation.md](docs/design/shared-foundation.md) — shared components, buttons, tables (desktop), depth tokens.
+- [docs/design/mobile-admin.md](docs/design/mobile-admin.md) — mobile admin layout patterns; keep consistent with §4 / §11 here.
+
+**Code anchors:** admin UI components live under `components/features/admin/`; canonical global surfaces in `app/globals.css`. Do not duplicate design rules into `CLAUDE.md` or `AGENTS.md`.
+
+---
+
+## 11. Component sizing tokens
+
+**Spacing scale (only):** `8` / `12` / `16` / `24` — see §12. Section gap **always 24px**.
+
+### Sidebar layout
+
+| Token | Value |
+|-------|--------|
+| Sidebar **container** width | **220px** (desktop) |
+| Sidebar **menu item** width | **180px** |
+| **Intent:** 220 − 180 = **40px** total horizontal rail — **20px padding left + 20px padding right** inside the sidebar for breathing room and alignment. |
+
+### Sidebar menu item (interactive row)
+
+| Property | Value |
+|----------|--------|
+| Width | **180px** |
+| Height | **35px** |
+| Gap between items | **15px** |
+| Radius | **10px** |
+| Selected background | `rgba(223, 189, 105, 0.10)` |
+| Selected border | `rgba(223, 189, 105, 0.16)` |
+| Unselected background | `rgba(28, 29, 34, 1)` |
+| Unselected border | `rgba(255, 255, 255, 0.06)` |
+| Selected label | Inter **12px** / **600** / `rgba(223,189,105,1)` |
+| Unselected label | Inter **12px** / **400** / `#C7C0B2` |
+| Nav **section title** (group label) | Inter **15px** / `#8A8478` |
+
+Mobile: **drawer or bottom nav only** — no persistent 220px rail.
+
+### Admin content
+
+| Token | Desktop | Mobile |
+|-------|---------|--------|
+| Max content width | none | — |
+| Page padding | **24px** | **16px** |
+| Section gap | **24** | **24** |
+| Card gap | **16** | **16** |
+
+### Cards
+
+| Token | Desktop | Mobile |
+|-------|---------|--------|
+| Border radius | **18px** | **18px** |
+| Padding | **20px** | **16px** |
+| Border | **1px** | **1px** |
+| KPI card min height | **88px** | **88px** |
+| Approval card min height | **120px** | **120px** |
+
+### Approval lanes (desktop)
+
+| Token | Value |
+|-------|--------|
+| Lane count | **3** |
+| Gap between lanes | **18px** |
+| Lane min width | **300px** |
+| Lane max height | `calc(100vh - headerHeight - pagePadding)` (header = actual admin header component) |
+| Scroll | Independent per lane |
+| Cards | **Full width** of lane |
+| Lane header | **44px** |
+
+### Buttons
+
+| Size | Height |
+|------|--------|
+| Small | **32px** |
+| Default | **40px** |
+| Large | **48px** |
+
+Radius **10px**. Mobile: **minimum tap target 44px** (use large/default heights or hit-padding).
+
+### Inputs / selects
+
+| Context | Height | Radius | Font size |
+|---------|--------|--------|-----------|
+| Desktop | **40px** | **10px** | **13px** |
+| Mobile | **44px** | **10px** | **13px** |
+
+### Badges
+
+| Property | Value |
+|----------|--------|
+| Height | **22px** |
+| Padding X | **8px** |
+| Radius | **999px** |
+| Font size | **10px** |
+
+### Text scale
+
+| Role | Desktop | Mobile |
+|------|---------|--------|
+| Page title | **24px** | **20px** |
+| Section title | **15px** | **15px** |
+| Card title | **14px** | **14px** |
+| Body | **12px** | **12px** |
+| Meta | **10px** | **10px** |
+
+**Minimum body size on small viewports:** project may enforce **12px** floor via `globals.css` — do not go below for primary operational copy.
+
+### Tables
+
+- **Desktop only.** Never table layout for primary mobile admin/cast lists — use cards.
+
+### Bottom navigation (mobile admin)
+
+| Token | Value |
+|-------|--------|
+| Height | **64px** |
+| Safe area | Respect `env(safe-area-inset-bottom)` |
+| Main content bottom padding | **≥ 88px** so CTAs sit above nav |
+
+---
+
+## 12. Alignment and consistency
+
+**Tie-in:** All numeric layout above must satisfy these rules — tokens are not negotiable individually.
+
+### Horizontal
+
+- Cards in the **same row**: **equal height**.
+- **Section headers** in one band: **same baseline**.
+- **KPI row:** equal height cards.
+- **Approval lanes:** fixed **3-column** layout; columns **equal width** (grid/flex with explicit fractions — no uneven auto tracks); cards **100%** of lane width.
+
+### Vertical rhythm
+
+- Only spacing tokens: **8 / 12 / 16 / 24**.
+- No arbitrary margins (e.g. 13px, 22px).
+- **Section gap:** always **24px**.
+- Card internal padding: **symmetric** top/bottom unless a single asymmetric element is documented.
+
+### Grid
+
+- **Desktop:** 12-column mental grid for alignment.
+- **Approval:** three equal lanes + §11 lane metrics.
+
+### Component consistency
+
+- Same component type → same **height, padding, font-size, radius** everywhere.
+
+### No visual drift
+
+- No mixed button heights, mixed radii, mixed weights in one hierarchy, uneven line-heights for the same role.
+
+### Empty space
+
+- Intentional only: **structural** (scale token) or **grouping**. No meaningless dead zones.
+
+### Card density
+
+- Do not stretch cards vertically without content; do not over-compress; readability beats ornament.
+
+### Scroll
+
+- Scroll only where needed. **Nested scroll:** allowed for **approval lanes**; **avoid** on standard pages.
+
+### Anti-patterns
+
+- Uneven card heights in one row; random spacing; mixed font sizes at same level; floating misaligned elements; charts without meaning; excessive whitespace without grouping purpose.
+
+---
+
+**Document version:** Admin/cast rebuild baseline — align implementation with `CURRENT_STATE.md` (Phase 2 planning; Production Card Map completed).

--- a/app/admin/(protected)/settings/page.tsx
+++ b/app/admin/(protected)/settings/page.tsx
@@ -13,28 +13,28 @@ export default async function SettingsPage() {
   ])
 
   return (
-    <div className="space-y-10 font-inter pb-10">
+    <div className="space-y-6 font-inter pb-8">
       {/* ── Page Header ── */}
-      <div className="flex flex-col gap-0.5 py-4">
-        <h1 className="text-[20px] font-semibold text-[#f4f1ea] tracking-[-0.31px]">設定</h1>
-        <p className="text-[12px] text-[#8a8478]">サイト全体に関する基本情報と動作の設定</p>
+      <div className="flex flex-col gap-0.5 py-2">
+        <h1 className="text-[17px] font-semibold text-[#f4f1ea] tracking-[-0.31px]">設定</h1>
+        <p className="text-[11px] text-[#8a8478]">サイト全体に関する基本情報と動作の設定</p>
       </div>
 
-      <div className="grid grid-cols-1 xl:grid-cols-2 gap-10 items-start">
+      <div className="grid grid-cols-1 xl:grid-cols-2 gap-5 items-start">
         {/* ── サイト設定 ── */}
         <section className="h-full">
-          <div className="mb-6">
-            <h2 className="text-[14px] font-bold tracking-[2px] text-[#f4f1ea] uppercase">サイト・ビジュアル設定</h2>
-            <p className="text-[11px] text-[#8a8478] mt-1">フロントエンドの雰囲気や演出を制御します</p>
+          <div className="mb-3 px-1">
+            <h2 className="text-[12px] font-semibold text-[#f4f1ea] tracking-[-0.1px]">サイト・ビジュアル設定</h2>
+            <p className="text-[11px] text-[#8a8478] mt-0.5">フロントエンドの雰囲気や演出を制御します</p>
           </div>
           <SettingsForm initialData={settings} />
         </section>
 
         {/* ── LINE 自動通知設定 ── */}
-        <section className="h-full">
-          <div className="mb-6">
-            <h2 className="text-[14px] font-bold tracking-[2px] text-[#f4f1ea] uppercase">LINE 自動通知設定</h2>
-            <p className="text-[11px] text-[#8a8478] mt-1">LINE公式アカウントからの自動通知スケジュールを管理します</p>
+        <section id="line-notifications" className="h-full scroll-mt-6">
+          <div className="mb-3 px-1">
+            <h2 className="text-[12px] font-semibold text-[#f4f1ea] tracking-[-0.1px]">LINE 自動通知設定</h2>
+            <p className="text-[11px] text-[#8a8478] mt-0.5">LINE公式アカウントからの自動通知スケジュールを管理します</p>
           </div>
           <LineNotificationManager
             key={lineNotifications.map((n) => n.id).join(',')}
@@ -46,9 +46,9 @@ export default async function SettingsPage() {
 
       {/* ── デザイン管理 ── */}
       <section>
-        <div className="mb-6">
-          <h2 className="text-[14px] font-bold tracking-[2px] text-[#f4f1ea] uppercase">デザイン管理</h2>
-          <p className="text-[11px] text-[#8a8478] mt-1">ヒーロービジュアル・ギャラリーなどのビジュアル設定を管理します</p>
+        <div className="mb-3 px-1">
+          <h2 className="text-[12px] font-semibold text-[#f4f1ea] tracking-[-0.1px]">デザイン管理</h2>
+          <p className="text-[11px] text-[#8a8478] mt-0.5">ヒーロービジュアル・ギャラリーなどのビジュアル設定を管理します</p>
         </div>
         <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
           {([
@@ -59,7 +59,7 @@ export default async function SettingsPage() {
             <Link
               key={item.href}
               href={item.href}
-              className="group flex items-center gap-4 rounded-[16px] border border-[#dfbd69]/18 bg-[#17181c] px-5 py-4 transition-all hover:bg-[#1c1d22] hover:border-[#dfbd69]/30"
+              className="group flex items-center gap-4 rounded-[18px] border border-[#ffffff0f] bg-[#17181c] px-5 py-4 transition-all hover:bg-[#1c1d22] hover:border-[#ffffff18]"
             >
               <div className="w-[38px] h-[38px] flex items-center justify-center rounded-[10px] bg-[#dfbd691a] shrink-0">
                 <item.Icon size={17} className="text-[#dfbd69]" />

--- a/components/features/admin/LineNotificationManager.tsx
+++ b/components/features/admin/LineNotificationManager.tsx
@@ -198,7 +198,7 @@ export function LineNotificationManager({
 
   // ── テーマ依存スタイル ───────────────────────────────────────────────────
   const cardBg = isDark
-    ? 'bg-black/94 border border-[#ffffff10] rounded-[18px] shadow-[0_8px_16px_-4px_rgba(0,0,0,0.4)]'
+    ? 'bg-[#17181c] border border-[#ffffff0f] rounded-[18px]'
     : 'bg-white border border-[#0000001a] rounded-[18px] shadow-[0_4px_24px_rgba(0,0,0,0.08)]'
   const labelSm = isDark ? 'text-[#5a5650]' : 'text-[#b0a898]'
   const textPrimary = isDark ? 'text-[#f4f1ea]' : 'text-[#1a1710]'
@@ -209,13 +209,13 @@ export function LineNotificationManager({
     : 'text-[10px] font-bold px-2 py-0.5 rounded-full border'
 
   return (
-    <div className="space-y-5">
+    <div className="space-y-4 rounded-[18px] border border-[#ffffff0f] bg-[#17181c] p-6">
 
       {/* ── ヘッダー ── */}
-      <div className={`flex items-center justify-between border-b ${divider} pb-4`}>
+      <div className={`flex items-center justify-between gap-3 border-b ${divider} pb-4`}>
         <div className="flex items-center gap-2.5">
-          <Bell size={14} className="text-gold" />
-          <h3 className={`text-sm font-bold tracking-widest uppercase ${textPrimary}`}>
+          <Bell size={15} className="text-gold" />
+          <h3 className={`text-[14px] font-semibold tracking-[-0.1px] ${textPrimary}`}>
             LINE 自動通知
           </h3>
           <span className={`text-[10px] font-bold px-2 py-0.5 rounded-full ${
@@ -226,7 +226,7 @@ export function LineNotificationManager({
         </div>
         <button
           onClick={() => { resetForm(); setShowForm(true) }}
-          className="flex items-center gap-2 px-6 py-2.5 bg-gold/10 border border-gold/30 text-gold text-[12px] font-bold tracking-widest rounded-[8px] hover:bg-gold/20 transition-all font-sans"
+          className="flex items-center gap-2 rounded-[10px] border border-[#dfbd6928] bg-[#dfbd6914] px-3 py-2 text-[11px] font-semibold text-[#dfbd69] hover:bg-[#dfbd691f] transition-colors font-sans"
         >
           <Plus size={14} /> 新規追加
         </button>
@@ -242,10 +242,8 @@ export function LineNotificationManager({
           isDark={isDark}
           F={F}
           labelSm={labelSm}
-          textPrimary={textPrimary}
           textSecondary={textSecondary}
           divider={divider}
-          tagBase={tagBase}
           linkedCasts={linkedCasts}
           onSave={handleSave}
           onCancel={resetForm}
@@ -256,10 +254,10 @@ export function LineNotificationManager({
 
       {/* ── 通知一覧 ── */}
       {notifications.length === 0 && !showForm ? (
-        <div className={`py-12 text-center ${cardBg}`}>
-          <Bell size={24} className={`mx-auto mb-3 ${labelSm}`} />
-          <p className={`text-xs ${textSecondary}`}>自動通知が設定されていません</p>
-          <p className={`text-[10px] mt-1 ${labelSm}`}>「新規追加」から最初の通知を作成してください</p>
+        <div className="rounded-[14px] border border-dashed border-[#dfbd6924] bg-[#dfbd6908] px-5 py-10 text-center">
+          <Bell size={22} className="mx-auto mb-3 text-[#dfbd69]" />
+          <p className="text-[13px] font-bold tracking-[0.04em] text-[#dfbd69]">通知未設定</p>
+          <p className="mt-2 text-[11px] font-medium leading-relaxed text-[#8a8478]">「新規追加」から最初の通知を作成してください</p>
         </div>
       ) : (
         <div className="space-y-2.5">
@@ -435,7 +433,7 @@ function NotificationCard({
 // ── 新規/編集フォーム ─────────────────────────────────────────────────────────
 function NotificationForm({
   form, setForm, editingId, isPending, isDark, F,
-  labelSm, textPrimary, divider, tagBase, linkedCasts,
+  labelSm, divider, linkedCasts,
   onSave, onCancel, toggleDay, toggleDate,
 }: {
   form: CreateLineNotificationInput
@@ -445,10 +443,8 @@ function NotificationForm({
   isDark: boolean
   F: ReturnType<typeof useAdminTheme>['F']
   labelSm: string
-  textPrimary: string
   textSecondary: string
   divider: string
-  tagBase: string
   linkedCasts: LinkedCast[]
   onSave: () => void
   onCancel: () => void
@@ -460,9 +456,9 @@ function NotificationForm({
   const inactiveDayClass = isDark ? 'border-white/10 text-[#5a5650] hover:border-white/20' : 'border-[#0000001a] text-[#b0a898] hover:border-[#00000030]'
 
   return (
-    <div className={`border ${borderColor} rounded-[18px] p-8 space-y-8 ${isDark ? 'bg-gold/4' : 'bg-[#926f340a]'}`}>
+    <div className={`border ${borderColor} rounded-[18px] p-5 space-y-5 ${isDark ? 'bg-[#1c1d22]' : 'bg-[#926f340a]'}`}>
       <div className="flex items-center justify-between">
-        <h4 className={`text-xs font-bold tracking-widest uppercase ${isDark ? 'text-gold' : 'text-[#926f34]'}`}>
+        <h4 className={`text-[12px] font-semibold ${isDark ? 'text-[#dfbd69]' : 'text-[#926f34]'}`}>
           {editingId ? '通知を編集' : '新規通知を追加'}
         </h4>
         <button onClick={onCancel} className={labelSm}><X size={14} /></button>
@@ -631,7 +627,7 @@ function NotificationForm({
       </div>
 
       {/* 保存ボタン */}
-      <div className={`flex justify-end gap-3 pt-8 border-t ${divider}`}>
+      <div className={`flex justify-end gap-3 pt-5 border-t ${divider}`}>
         <button onClick={onCancel} className={`px-6 py-2.5 text-[12px] font-bold border rounded-[8px] transition-all font-sans ${
           isDark ? 'border-white/10 text-[#8a8478] hover:text-[#f4f1ea]' : 'border-[#0000001a] text-[#7a7268] hover:text-[#1a1710]'
         }`}>

--- a/components/features/admin/SettingsForm.tsx
+++ b/components/features/admin/SettingsForm.tsx
@@ -40,27 +40,25 @@ export function SettingsForm({ initialData }: { initialData?: SettingsData | nul
 
   return (
     <div className="w-full">
-      <div className={`${F.card} p-10 md:p-14 h-full relative overflow-hidden flex flex-col`}>
-        {/* Subtle accent decoration */}
-        <div className="absolute top-0 right-0 w-96 h-96 bg-gold/5 blur-[120px] -mr-48 -mt-48 rounded-full" />
-        <div className="absolute top-0 left-0 right-0 h-px bg-linear-to-r from-transparent via-gold/30 to-transparent" />
-
-        <div className="mb-14 relative z-10">
-          <h2 className={`text-3xl font-serif tracking-tight mb-3 ${F.heading}`}>サイト設定</h2>
-          <p className="text-[11px] font-bold tracking-[4px] text-[#5a5650] uppercase italic">サイト全体の雰囲気とビジュアル演出を管理します</p>
+      <div className="h-full rounded-[18px] border border-[#ffffff0f] bg-[#17181c] p-6 flex flex-col">
+        <div className="mb-6 flex items-start justify-between gap-4 border-b border-[#ffffff0a] pb-4">
+          <div>
+            <h2 className={`text-[14px] font-semibold tracking-[-0.1px] ${F.heading}`}>サイト設定</h2>
+            <p className="mt-1 text-[11px] leading-relaxed text-[#8a8478]">サイト全体の雰囲気とビジュアル演出を管理します</p>
+          </div>
         </div>
 
-        <form onSubmit={handleSubmit} className="space-y-16 relative z-10 flex-1 flex flex-col">
+        <form onSubmit={handleSubmit} className="space-y-6 flex-1 flex flex-col">
           {/* Section: 本日のムード */}
-          <div className="space-y-8">
-            <div className="flex items-center gap-4 mb-8">
-              <div className="h-px w-12 bg-gold/40" />
-              <span className="text-[11px] font-bold tracking-[5px] text-[#5a5650] uppercase">本日のムード</span>
+          <div className="space-y-4">
+            <div className="flex items-center gap-3">
+              <span className="h-2 w-2 rounded-full bg-[#dfbd69]" />
+              <span className="text-[11px] font-semibold text-[#c7c0b2]">本日のムード</span>
             </div>
 
             <div className="group">
               <label htmlFor="today_mood" className={F.label}>トップページ見出しメッセージ</label>
-              <p className={`text-[12px] mb-6 text-[#8a8478] leading-relaxed max-w-2xl`}>
+              <p className="text-[12px] mb-3 text-[#8a8478] leading-relaxed">
                 フロントページの最上部に表示されるメッセージです。店舗の今日の雰囲気やキャッチコピーを入力してください。
               </p>
               <input
@@ -68,29 +66,29 @@ export function SettingsForm({ initialData }: { initialData?: SettingsData | nul
                 name="today_mood"
                 type="text"
                 defaultValue={initialData?.today_mood || ''}
-                className={`${F.input} h-14 text-base`}
+                className={`${F.input} h-11`}
                 placeholder="本日も皆様のご来店を心よりお待ち申し上げております。"
               />
-              <p className="mt-3 text-[10px] text-[#5a5650] tracking-widest italic opacity-0 group-focus-within:opacity-100 transition-opacity">保存するとフロントページに即時反映されます</p>
+              <p className="mt-2 text-[11px] text-[#5a5650] opacity-0 group-focus-within:opacity-100 transition-opacity">保存するとフロントページに即時反映されます</p>
             </div>
           </div>
 
           {/* Section: ビジュアル演出 */}
-          <div className="space-y-8 pt-10 border-t border-[#ffffff08]">
-            <div className="flex items-center gap-4 mb-8">
-              <div className="h-px w-12 bg-gold/40" />
-              <span className="text-[11px] font-bold tracking-[5px] text-[#5a5650] uppercase">ビジュアル演出</span>
+          <div className="space-y-4 pt-5 border-t border-[#ffffff08]">
+            <div className="flex items-center gap-3">
+              <span className="h-2 w-2 rounded-full bg-[#dfbd69]" />
+              <span className="text-[11px] font-semibold text-[#c7c0b2]">ビジュアル演出</span>
             </div>
 
-            <div className="grid grid-cols-1 lg:grid-cols-2 gap-10">
+            <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
               <div className="flex flex-col h-full">
                 <label htmlFor="hero_transition_mode" className={F.label}>ヒーロー画像のトランジション</label>
-                <div className="relative flex-1 min-h-[56px]">
+                <div className="relative flex-1 min-h-[44px]">
                   <select
                     id="hero_transition_mode"
                     name="hero_transition_mode"
                     defaultValue={initialData?.hero_transition_mode || 'ripple'}
-                    className={`${F.input} h-full pr-12 appearance-none text-base`}
+                    className={`${F.input} h-11 pr-10 appearance-none`}
                   >
                     <option value="ripple">リップル（シェーダークロスフェード）★ おすすめ</option>
                     <option value="fade">シンプルフェード（標準）</option>
@@ -98,42 +96,37 @@ export function SettingsForm({ initialData }: { initialData?: SettingsData | nul
                     <option value="zoom">ズームイン（奥行き感）</option>
                     <option value="burn">露光フェード（アーティスティック）</option>
                   </select>
-                  <div className="absolute right-5 top-1/2 -translate-y-1/2 pointer-events-none text-gold/80">
-                    <Check size={18} />
+                  <div className="absolute right-4 top-1/2 -translate-y-1/2 pointer-events-none text-gold/80">
+                    <Check size={15} />
                   </div>
                 </div>
-                <p className={`${F.noteText} mt-5 leading-relaxed text-xs`}>
+                <p className={`${F.noteText} mt-3 leading-relaxed`}>
                   「リップル」はWebGLシェーダーを使用した高品質なエフェクトです。その他のモードはCSSアニメーションで動作します。
                 </p>
               </div>
 
-              <div className="bg-white/3 border border-white/10 p-8 rounded-[12px] flex flex-col justify-center min-h-section">
-                <p className="text-[11px] font-bold tracking-[3px] text-gold uppercase mb-3">ヒント</p>
-                <p className="text-[13px] text-[#8a8478] leading-relaxed italic">
+              <div className="bg-[#1c1d22] border border-[#ffffff0f] p-4 rounded-[14px] flex flex-col justify-center">
+                <p className="text-[11px] font-semibold text-[#dfbd69] mb-2">ヒント</p>
+                <p className="text-[12px] text-[#8a8478] leading-relaxed">
                   「リップル」はカスタムシェーダーによる水面のようなクロスフェード効果で、Animoのブランドイメージに最もマッチしたプレミアムな演出です。
                 </p>
               </div>
             </div>
           </div>
 
-          <div className="pt-12 mt-auto">
-            <button
+          <div className="pt-4 mt-auto">
+            <Button
               type="submit"
               disabled={isPending}
-              className="w-full relative group h-16 bg-gold overflow-hidden rounded-[10px] transition-all active:scale-[0.99] disabled:opacity-50 disabled:cursor-not-allowed shadow-[0_15px_35px_-10px_rgba(223,189,105,0.4)] flex items-center justify-center"
+              className="w-full h-11 bg-gold text-black hover:bg-gold/90 text-[12px] font-bold tracking-[0.08em]"
             >
-              <div className="absolute inset-0 w-full h-full bg-white/25 translate-y-full group-hover:translate-y-0 transition-transform duration-500" />
-              <div className="relative z-10 flex items-center gap-4">
-                {isPending ? (
-                  <Loader2 size={18} className="animate-spin text-black" />
-                ) : (
-                  <Check size={18} className="text-black" />
-                )}
-                <span className="text-black text-[12px] font-bold tracking-[4px] uppercase font-sans">
-                  {isPending ? '保存中...' : '設定を保存する'}
-                </span>
-              </div>
-            </button>
+              {isPending ? (
+                <Loader2 size={16} className="animate-spin text-black" />
+              ) : (
+                <Check size={16} className="text-black" />
+              )}
+              {isPending ? '保存中...' : '設定を保存する'}
+            </Button>
           </div>
         </form>
       </div>


### PR DESCRIPTION
## Summary
Refactor the admin settings/design page to reuse existing admin UI patterns for layout, typography, cards, inputs, buttons, and empty states while preserving current functionality.

## Changes
- Aligned the settings page header, section spacing, and design links with common admin page density.
- Reworked the site settings form card to use existing admin card, input, label, and button patterns.
- Updated LINE notification manager surfaces and empty state to match existing admin UI conventions.

## Impact
- Affects /admin/settings visual presentation only.
- No business logic, API routes, database schema, or notification behavior changes.
- No breaking changes.

## Test Plan
- pnpm lint
- pnpm run build

## Notes
- Existing lint warnings remain unrelated to this change.
- Build still shows the existing Next.js middleware deprecation warning.