### PR TITLE
fix(cast/today): bundle checkin + reservations into single submit

### DIFF
--- a/app/(cast)/cast/today/page.tsx
+++ b/app/(cast)/cast/today/page.tsx
@@ -2,8 +2,6 @@ import { redirect } from 'next/navigation';
 import { getCurrentCast } from '@/lib/actions/cast-auth';
 import { getCastTodayCheckin, getCastTodayReservations, getTodaySubmissionState } from '@/lib/actions/today';
 import { createClient } from '@/lib/supabase/server';
-import { CheckinForm } from '@/components/features/today/CheckinForm';
-import { ReservationForm } from '@/components/features/today/ReservationForm';
 import {
   CastMobileBackLink,
   CastMobileCard,
@@ -11,6 +9,7 @@ import {
   CastMobileShell,
   CastMobileSectionTitle,
 } from '@/components/features/cast/CastMobileShell';
+import { CastTodayClientShell } from '@/components/features/today/CastTodayClientShell';
 import { getJstDateString, formatShiftTime } from '@/lib/date-utils';
 import { isMasterAccount } from '@/lib/config/master';
 
@@ -30,7 +29,6 @@ export default async function CastTodayPage() {
   const supabase = await createClient();
   const today = getJstDateString();
 
-  // auth user の email を取得（master 判定に使用）
   const { data: { user } } = await supabase.auth.getUser();
   const isMaster = isMasterAccount(user?.email);
 
@@ -42,14 +40,11 @@ export default async function CastTodayPage() {
 
   const submissionState = await getTodaySubmissionState();
 
-  // マスターアカウントは締切後でも編集可能
   const isSubmissionClosed = submissionState.isClosed && !isMaster;
-  // マスターが締切後にアクセスしている場合にバナーを出す
   const isMasterOverride = isMaster && submissionState.isClosed;
 
   const allReservations = (todayReservations || []) as CastDashboardReservationRow[];
 
-  // 同伴と通常来店予定を分離
   const douhanReservationRaw = allReservations.find(r => r.reservation_type === 'douhan') ?? null;
   const normalReservations = allReservations
     .filter(r => r.reservation_type === 'reservation')
@@ -82,32 +77,33 @@ export default async function CastTodayPage() {
           description="出勤確認・同伴情報・来店予定をまとめて送信します。"
         />
 
-        <CastMobileCard className="px-5 py-4">
-          <div className="text-xs uppercase tracking-[0.16em] text-[#6b7280]">Today&apos;s Schedule</div>
-          <div className="mt-3 text-base font-bold text-[#f7f4ed]">
-            {todayShift
-              ? formatShiftTime(todayShift.start_time, todayShift.end_time)
-              : '本日の出勤予定はありません'}
+        {/* ⑤ 修正: padding を card 内コンテンツ側に移し、ベゼル 1px が正しく表示されるようにする */}
+        <CastMobileCard>
+          <div className="px-5 py-4">
+            <div className="text-xs uppercase tracking-[0.16em] text-[#6b7280]">Today&apos;s Schedule</div>
+            <div className="mt-3 text-base font-bold text-[#f7f4ed]">
+              {todayShift
+                ? formatShiftTime(todayShift.start_time, todayShift.end_time)
+                : '本日の出勤予定はありません'}
+            </div>
           </div>
         </CastMobileCard>
 
-        {/* ── 01: 出勤確認（同伴フォーム内包）── */}
+        {/* ── 01 + 02 統合フォームシェル ── */}
         <div className="[&_input]:bg-[#10141d] [&_input]:text-[#f7f4ed] [&_select]:bg-[#10141d] [&_select]:text-[#f7f4ed] [&_textarea]:bg-[#10141d] [&_textarea]:text-[#f7f4ed]">
-          <CheckinForm
-            existing={todayCheckin}
-            existingDouhan={existingDouhan}
-            isSubmissionClosed={isSubmissionClosed}
-            deadlineLabel={submissionState.deadlineLabel}
-            isMasterOverride={isMasterOverride}
-          />
-        </div>
-
-        {/* ── 02: 通常来店予定（任意・複数可）── */}
-        <div className="[&_input]:bg-[#10141d] [&_input]:text-[#f7f4ed] [&_select]:bg-[#10141d] [&_select]:text-[#f7f4ed] [&_textarea]:bg-[#10141d] [&_textarea]:text-[#f7f4ed]">
-          <ReservationForm
-            reservations={normalReservations}
-            isSubmissionClosed={isSubmissionClosed}
-            deadlineLabel={submissionState.deadlineLabel}
+          <CastTodayClientShell
+            checkinProps={{
+              existing: todayCheckin,
+              existingDouhan,
+              isSubmissionClosed,
+              deadlineLabel: submissionState.deadlineLabel,
+              isMasterOverride,
+            }}
+            reservationProps={{
+              reservations: normalReservations,
+              isSubmissionClosed,
+              deadlineLabel: submissionState.deadlineLabel,
+            }}
           />
         </div>
       </main>

--- a/components/features/today/CastTodayClientShell.tsx
+++ b/components/features/today/CastTodayClientShell.tsx
@@ -1,0 +1,115 @@
+'use client'
+
+import { useRef, useState } from 'react'
+import { addReservation } from '@/lib/actions/today'
+import { toast } from 'sonner'
+import { CheckinForm, type CheckinFormHandle } from './CheckinForm'
+import { ReservationForm, type PendingReservation } from './ReservationForm'
+
+type ExistingCheckin = {
+  has_change: boolean
+  change_note?: string
+  is_absent: boolean
+  memo?: string
+  approval_status?: 'pending' | 'approved' | 'rejected'
+} | null
+
+type ExistingDouhanReservation = {
+  id: string
+  visit_time: string
+  guest_name: string
+  guest_count?: number | null
+  note?: string | null
+} | null
+
+type SavedReservation = {
+  id: string
+  visit_time: string
+  guest_name: string
+  guest_count?: number | null
+  reservation_type: string
+  note?: string
+}
+
+type Props = {
+  checkinProps: {
+    existing: ExistingCheckin
+    existingDouhan?: ExistingDouhanReservation
+    isSubmissionClosed: boolean
+    deadlineLabel: string
+    isMasterOverride?: boolean
+  }
+  reservationProps: {
+    reservations: SavedReservation[]
+    isSubmissionClosed: boolean
+    deadlineLabel: string
+  }
+}
+
+export function CastTodayClientShell({ checkinProps, reservationProps }: Props) {
+  const checkinRef = useRef<CheckinFormHandle>(null)
+  const [pendingReservations, setPendingReservations] = useState<PendingReservation[]>([])
+  const [isSubmitting, setIsSubmitting] = useState(false)
+
+  function handleAddPending(r: PendingReservation) {
+    setPendingReservations(prev => [...prev, r])
+  }
+
+  function handleRemovePending(id: string) {
+    setPendingReservations(prev => prev.filter(r => r.id !== id))
+  }
+
+  async function handleUnifiedSubmit() {
+    setIsSubmitting(true)
+    try {
+      const checkinResult = await checkinRef.current?.submit()
+      if (checkinResult?.error) return
+
+      const errors: string[] = []
+      for (const r of pendingReservations) {
+        const fd = new FormData()
+        fd.set('visit_time', r.visit_time)
+        fd.set('guest_name', r.guest_name)
+        if (r.guest_count != null) fd.set('guest_count', String(r.guest_count))
+        if (r.note) fd.set('note', r.note)
+        fd.set('reservation_type', 'reservation')
+        fd.set('visit_certainty', 'maybe')
+        const result = await addReservation(fd)
+        if (result.error) errors.push(result.error)
+      }
+
+      if (errors.length === 0) {
+        if (pendingReservations.length > 0) {
+          toast.success(`来店予定 ${pendingReservations.length} 件を送信しました`)
+        }
+        setPendingReservations([])
+      } else {
+        toast.error(`一部の来店予定の送信に失敗しました: ${errors.join(' / ')}`)
+      }
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  return (
+    <>
+      <CheckinForm ref={checkinRef} {...checkinProps} hideSubmitButton />
+      <ReservationForm
+        {...reservationProps}
+        pendingReservations={pendingReservations}
+        onAddPending={handleAddPending}
+        onRemovePending={handleRemovePending}
+      />
+      {!checkinProps.isSubmissionClosed && (
+        <button
+          type="button"
+          onClick={handleUnifiedSubmit}
+          disabled={isSubmitting}
+          className="h-[56px] w-full rounded-[16px] bg-[#c9a76a] text-[15px] font-bold text-[#0b0d12] transition-all disabled:opacity-50 hover:bg-[#d4b575] active:scale-[0.99]"
+        >
+          {isSubmitting ? '送信中...' : '本日の情報を送信する'}
+        </button>
+      )}
+    </>
+  )
+}

--- a/components/features/today/CheckinForm.tsx
+++ b/components/features/today/CheckinForm.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import { forwardRef, useImperativeHandle, useRef, useState } from 'react'
 import { submitCheckin } from '@/lib/actions/today'
 import { toast } from 'sonner'
 import { CheckCircle } from 'lucide-react'
@@ -23,6 +23,19 @@ type ExistingDouhanReservation = {
   note?: string | null
 } | null
 
+export type CheckinFormHandle = {
+  submit: () => Promise<{ error?: string; message?: string } | undefined>
+}
+
+type CheckinFormProps = {
+  existing: ExistingCheckin
+  existingDouhan?: ExistingDouhanReservation
+  isSubmissionClosed: boolean
+  deadlineLabel: string
+  isMasterOverride?: boolean
+  hideSubmitButton?: boolean
+}
+
 function deriveInitialStatus(
   existing: ExistingCheckin,
   existingDouhan: ExistingDouhanReservation,
@@ -32,352 +45,366 @@ function deriveInitialStatus(
   return 'work'
 }
 
-export function CheckinForm({
-  existing,
-  existingDouhan,
-  isSubmissionClosed,
-  deadlineLabel,
-  isMasterOverride = false,
-}: {
-  existing: ExistingCheckin
-  existingDouhan?: ExistingDouhanReservation
-  isSubmissionClosed: boolean
-  deadlineLabel: string
-  isMasterOverride?: boolean
-}) {
-  const initialStatus = deriveInitialStatus(existing, existingDouhan ?? null)
-  const [status, setStatus] = useState<Status>(() =>
-    initialStatus
-  )
-  const [confirmedStatus, setConfirmedStatus] = useState<Status>(initialStatus)
-  const [isSubmitting, setIsSubmitting] = useState(false)
-  const [submitted, setSubmitted] = useState(!!(existing || existingDouhan))
-  const [approvalStatus, setApprovalStatus] = useState(
-    existing?.approval_status ?? null
-  )
-  const [submitError, setSubmitError] = useState<string | null>(null)
+export const CheckinForm = forwardRef<CheckinFormHandle, CheckinFormProps>(
+  function CheckinForm(
+    {
+      existing,
+      existingDouhan,
+      isSubmissionClosed,
+      deadlineLabel,
+      isMasterOverride = false,
+      hideSubmitButton = false,
+    },
+    ref,
+  ) {
+    const initialStatus = deriveInitialStatus(existing, existingDouhan ?? null)
+    const [status, setStatus] = useState<Status>(() => initialStatus)
+    const [confirmedStatus, setConfirmedStatus] = useState<Status>(initialStatus)
+    const [isSubmitting, setIsSubmitting] = useState(false)
+    const [submitted, setSubmitted] = useState(!!(existing || existingDouhan))
+    const [approvalStatus, setApprovalStatus] = useState(
+      existing?.approval_status ?? null,
+    )
+    const [submitError, setSubmitError] = useState<string | null>(null)
+    const internalFormRef = useRef<HTMLFormElement>(null)
 
-  const inputClass =
-    'h-[48px] w-full rounded-[12px] border-none bg-black/40 px-3 text-[13px] text-[#f7f4ed] placeholder:text-[rgba(247,244,237,0.4)] focus:outline-hidden focus:ring-1 focus:ring-[#c9a76a] transition-all'
+    const inputClass =
+      'h-[48px] w-full rounded-[12px] border-none bg-black/40 px-3 text-[13px] text-[#f7f4ed] placeholder:text-[rgba(247,244,237,0.4)] focus:outline-hidden focus:ring-1 focus:ring-[#c9a76a] transition-all'
 
-  const isLocked = isSubmissionClosed || approvalStatus === 'approved'
+    const isLocked = isSubmissionClosed || approvalStatus === 'approved'
 
-  async function handleAbsentClick(): Promise<void> {
-    if (isLocked) return
-    if (status !== 'absent') {
-      const confirmed = window.confirm(
-        '本日を欠勤として提出します。よろしいですか？'
-      )
-      if (!confirmed) return
-    }
-    setStatus('absent')
-  }
+    async function performSubmit(): Promise<{ error?: string; message?: string } | undefined> {
+      const previousState = { status: confirmedStatus, submitted, approvalStatus }
+      setIsSubmitting(true)
+      setSubmitted(true)
+      setApprovalStatus('pending')
+      setSubmitError(null)
 
-  async function handleSubmit(e: React.FormEvent<HTMLFormElement>): Promise<void> {
-    e.preventDefault()
-    if (isLocked) return
+      const fd = new FormData(internalFormRef.current!)
+      fd.set('status', status)
+      fd.set('has_change', status === 'douhan' && !!fd.get('change_note') ? 'true' : 'false')
+      fd.set('is_absent', status === 'absent' ? 'true' : 'false')
 
-    if (status === 'douhan') {
-      const guestName = (
-        e.currentTarget.querySelector<HTMLInputElement>('[name="douhan_guest_name"]')?.value ?? ''
-      ).trim()
-      const visitTime =
-        e.currentTarget.querySelector<HTMLInputElement>('[name="douhan_visit_time"]')?.value ?? ''
-      if (!guestName || !visitTime) {
-        toast.error('同伴のお客様名と時間を入力してください')
-        return
+      const result = await submitCheckin(fd)
+      if (result.error) {
+        setStatus(previousState.status)
+        setSubmitted(previousState.submitted)
+        setApprovalStatus(previousState.approvalStatus)
+        setSubmitError(result.error)
+        toast.error(result.error)
+        setIsSubmitting(false)
+        return { error: result.error }
       }
-    }
 
-    const previousState = {
-      status: confirmedStatus,
-      submitted,
-      approvalStatus,
-    }
-
-    setIsSubmitting(true)
-    setSubmitted(true)
-    setApprovalStatus('pending')
-    setSubmitError(null)
-
-    const fd = new FormData(e.currentTarget)
-    fd.set('status', status)
-    fd.set('has_change', status === 'douhan' && !!fd.get('change_note') ? 'true' : 'false')
-    fd.set('is_absent', status === 'absent' ? 'true' : 'false')
-
-    const result = await submitCheckin(fd)
-    if (result.error) {
-      setStatus(previousState.status)
-      setSubmitted(previousState.submitted)
-      setApprovalStatus(previousState.approvalStatus)
-      setSubmitError(result.error)
-      toast.error(result.error)
-    } else {
       toast.success(result.message ?? '本日の確認を送信しました')
       if ('warning' in result && result.warning) {
         toast.error(result.warning as string)
       }
       setConfirmedStatus(status)
+      setIsSubmitting(false)
+      return { message: result.message }
     }
-    setIsSubmitting(false)
-  }
 
-  // ── Approved + no changes → compact green banner ──
-  if (
-    submitted &&
-    approvalStatus === 'approved' &&
-    status !== 'absent'
-  ) {
-    return (
-      <div className="rounded-[18px] border border-[rgba(51,179,107,0.27)] bg-[rgba(51,179,107,0.12)] p-5 flex items-center gap-3">
-        <CheckCircle size={20} className="text-green-500 shrink-0" />
-        <div>
-          <p className="text-sm font-bold text-[#33b36b]">本日の確認 承認済み</p>
-          <p className="text-xs text-[#33b36b] mt-0.5">
-            {status === 'douhan' ? '同伴あり出勤' : '予定通り出勤'}
-          </p>
+    useImperativeHandle(ref, () => ({
+      async submit() {
+        if (isLocked) return undefined
+        if (status === 'douhan') {
+          const guestName = (
+            internalFormRef.current
+              ?.querySelector<HTMLInputElement>('[name="douhan_guest_name"]')
+              ?.value ?? ''
+          ).trim()
+          const visitTime =
+            internalFormRef.current?.querySelector<HTMLInputElement>(
+              '[name="douhan_visit_time"]',
+            )?.value ?? ''
+          if (!guestName || !visitTime) {
+            toast.error('同伴のお客様名と時間を入力してください')
+            return { error: '同伴のお客様名と時間を入力してください' }
+          }
+        }
+        return performSubmit()
+      },
+    }))
+
+    async function handleSubmit(e: React.FormEvent<HTMLFormElement>): Promise<void> {
+      e.preventDefault()
+      if (isLocked) return
+      if (status === 'douhan') {
+        const guestName = (
+          e.currentTarget.querySelector<HTMLInputElement>('[name="douhan_guest_name"]')
+            ?.value ?? ''
+        ).trim()
+        const visitTime =
+          e.currentTarget.querySelector<HTMLInputElement>('[name="douhan_visit_time"]')
+            ?.value ?? ''
+        if (!guestName || !visitTime) {
+          toast.error('同伴のお客様名と時間を入力してください')
+          return
+        }
+      }
+      await performSubmit()
+    }
+
+    async function handleAbsentClick(): Promise<void> {
+      if (isLocked) return
+      if (status !== 'absent') {
+        const confirmed = window.confirm('本日を欠勤として提出します。よろしいですか？')
+        if (!confirmed) return
+      }
+      setStatus('absent')
+    }
+
+    // ── Approved + no changes → compact green banner ──
+    if (submitted && approvalStatus === 'approved' && status !== 'absent') {
+      return (
+        <div className="rounded-[18px] border border-[rgba(51,179,107,0.27)] bg-[rgba(51,179,107,0.12)] p-5 flex items-center gap-3">
+          <CheckCircle size={20} className="text-green-500 shrink-0" />
+          <div>
+            <p className="text-sm font-bold text-[#33b36b]">本日の確認 承認済み</p>
+            <p className="text-xs text-[#33b36b] mt-0.5">
+              {status === 'douhan' ? '同伴あり出勤' : '予定通り出勤'}
+            </p>
+          </div>
+          {!isSubmissionClosed ? (
+            <button
+              onClick={() => setSubmitted(false)}
+              className="ml-auto text-xs text-gray-400 hover:text-gold"
+            >
+              修正
+            </button>
+          ) : null}
         </div>
-        {!isSubmissionClosed ? (
-          <button
-            onClick={() => setSubmitted(false)}
-            className="ml-auto text-xs text-gray-400 hover:text-gold"
-          >
-            修正
-          </button>
-        ) : null}
+      )
+    }
+
+    const statusLabel =
+      approvalStatus === 'pending'
+        ? '店長承認待ち'
+        : approvalStatus === 'rejected'
+          ? '差し戻し'
+          : approvalStatus === 'approved'
+            ? '承認済み'
+            : '未提出'
+
+    function cardClass(s: Status): string {
+      const base =
+        'flex-1 rounded-[14px] px-3 py-4 text-center transition-all duration-200 cursor-pointer outline-none focus:outline-none ring-0 focus:ring-0 appearance-none'
+      if (status !== s) {
+        return `${base} border border-[#2a2d36] bg-[#1a1d24] text-[rgba(247,244,237,0.4)] hover:bg-[#1f222a]`
+      }
+      if (s === 'work') {
+        return `${base} border border-[#c9a76a] bg-[rgba(201,167,106,0.15)] text-[#c9a76a] shadow-[0_0_12px_rgba(201,167,106,0.15)]`
+      }
+      if (s === 'douhan') {
+        return `${base} border border-[#9fbc73] bg-[rgba(159,188,115,0.16)] text-[#c8d99a] shadow-[0_0_14px_rgba(159,188,115,0.16)]`
+      }
+      return `${base} border border-[#d4785a] bg-[rgba(212,120,90,0.14)] text-[#e08a73] shadow-[0_0_12px_rgba(212,120,90,0.14)]`
+    }
+
+    return (
+      <div className="rounded-[18px] card-premium-skin">
+        <div className="card-premium-skin__surface rounded-[18px] overflow-hidden px-[18px] py-[18px]">
+          {/* Header */}
+          <div className="mb-4 flex items-center justify-between gap-3">
+            <p className="text-[10px] font-bold tracking-[1.2px] uppercase text-[#6b7280]">
+              01 — 本日の出勤確認
+            </p>
+            <span
+              className={`rounded-full px-2.5 py-1 text-[10px] font-bold ${
+                approvalStatus === 'approved'
+                  ? 'bg-[rgba(51,179,107,0.12)] text-[#33b36b]'
+                  : approvalStatus === 'rejected'
+                    ? 'bg-[rgba(224,106,106,0.12)] text-[#e06a6a]'
+                    : approvalStatus === 'pending'
+                      ? 'bg-[rgba(230,162,60,0.12)] text-[#e6a23c]'
+                      : 'bg-[rgba(255,255,255,0.08)] text-[#6b7280]'
+              }`}
+            >
+              {statusLabel}
+            </span>
+          </div>
+
+          {/* Master override banner */}
+          {isMasterOverride && (
+            <div className="mb-4 flex items-center gap-2 rounded-xl border border-[#dfbd69]/30 bg-[rgba(223,189,105,0.08)] px-3 py-2">
+              <span className="shrink-0 rounded-full bg-[#dfbd69] px-2 py-0.5 text-[9px] font-bold tracking-widest text-[#0b0d12] uppercase">
+                MASTER
+              </span>
+              <p className="text-[11px] font-bold text-[#dfbd69]">
+                管理者オーバーライド中 — テストモード（締切後も編集可）
+              </p>
+            </div>
+          )}
+
+          {/* Status banners */}
+          {isSubmissionClosed ? (
+            <p className="mb-4 rounded-xl border border-red-100 bg-red-50 px-3 py-2 text-xs text-red-600">
+              本日の提出締切 {deadlineLabel} を過ぎたため、現在は編集できません。
+            </p>
+          ) : approvalStatus === 'pending' ? (
+            <p className="mb-4 rounded-xl border border-amber-100 bg-amber-50 px-3 py-2 text-xs text-amber-700">
+              提出済みです。店長の承認後に管理画面へ反映されます。
+            </p>
+          ) : approvalStatus === 'rejected' ? (
+            <p className="mb-4 rounded-xl border border-red-100 bg-red-50 px-3 py-2 text-xs text-red-600">
+              差し戻しされています。内容を見直して再提出してください。
+            </p>
+          ) : null}
+
+          {submitError ? (
+            <p className="mb-4 rounded-xl border border-red-100 bg-red-50 px-3 py-2 text-xs text-red-600">
+              {submitError}
+            </p>
+          ) : null}
+
+          <form ref={internalFormRef} onSubmit={handleSubmit} className="space-y-5">
+            {/* ── 3-state selector ── */}
+            <div className="grid grid-cols-3 gap-2">
+              <button
+                type="button"
+                disabled={isLocked}
+                onClick={() => setStatus('work')}
+                className={cardClass('work')}
+              >
+                <div className="text-[14px] font-bold leading-[21px]">予定通り</div>
+                <div className="mt-1 text-[10px] opacity-70">出勤</div>
+              </button>
+
+              <button
+                type="button"
+                disabled={isLocked}
+                onClick={() => setStatus('douhan')}
+                className={cardClass('douhan')}
+              >
+                <div className="text-[14px] font-bold leading-[21px]">同伴</div>
+                <div className="mt-1 text-[10px] opacity-70">出勤</div>
+              </button>
+
+              <button
+                type="button"
+                disabled={isLocked}
+                onClick={handleAbsentClick}
+                className={cardClass('absent')}
+              >
+                <div className="text-[14px] font-bold leading-[21px]">休み</div>
+                <div className="mt-1 text-[10px] opacity-70">欠勤</div>
+              </button>
+            </div>
+
+            {/* ── 同伴フォーム（必須）── */}
+            {status === 'douhan' && (
+              <div className="rounded-[14px] ring-1 ring-[#9fbc73]/20 bg-[rgba(159,188,115,0.06)] p-4 space-y-4">
+                <p className="text-[10px] font-bold tracking-[1.2px] uppercase text-[#c8d99a]/75 mb-1">
+                  同伴情報（必須）
+                </p>
+                <div>
+                  <label className="mb-1 block text-[11px] text-[#6b7280]">
+                    時間 <span className="text-[#dfbd69]">*</span>
+                  </label>
+                  <input
+                    name="douhan_visit_time"
+                    type="time"
+                    required={status === 'douhan'}
+                    defaultValue={existingDouhan?.visit_time?.slice(0, 5) ?? ''}
+                    disabled={isLocked}
+                    className={inputClass}
+                  />
+                </div>
+                <div>
+                  <label className="mb-1 block text-[11px] text-[#6b7280]">
+                    お客様名 <span className="text-[#dfbd69]">*</span>
+                  </label>
+                  <input
+                    name="douhan_guest_name"
+                    type="text"
+                    required={status === 'douhan'}
+                    defaultValue={existingDouhan?.guest_name ?? ''}
+                    placeholder="山田"
+                    disabled={isLocked}
+                    className={inputClass}
+                  />
+                  <p className="mt-1 text-[11px] text-[#6b7280]">「様」はつけずに入力してください</p>
+                </div>
+                <div>
+                  <label className="mb-1 block text-[11px] text-[#6b7280]">人数</label>
+                  <input
+                    name="douhan_guest_count"
+                    type="number"
+                    min="1"
+                    inputMode="numeric"
+                    placeholder="2"
+                    defaultValue={existingDouhan?.guest_count ?? ''}
+                    disabled={isLocked}
+                    className={inputClass}
+                  />
+                </div>
+                <div className="pt-2 border-t border-[#dfbd69]/10">
+                  <label className="mb-1 flex items-center gap-1.5 text-[11px] text-[rgba(247,244,237,0.7)]">
+                    変更内容（任意）
+                    <span className="text-[10px] text-[#6b7280]">例：来店時間の変更など</span>
+                  </label>
+                  <input
+                    name="change_note"
+                    type="text"
+                    placeholder="例：22:00→23:00"
+                    defaultValue={existing?.change_note ?? ''}
+                    disabled={isLocked}
+                    className={inputClass}
+                  />
+                </div>
+                <div>
+                  <label className="mb-1 block text-[11px] text-[rgba(247,244,237,0.7)]">メモ（任意）</label>
+                  <input
+                    name="douhan_note"
+                    type="text"
+                    placeholder="待ち合わせ場所や補足があれば入力してください"
+                    defaultValue={existingDouhan?.note ?? ''}
+                    disabled={isLocked}
+                    className={inputClass}
+                  />
+                </div>
+              </div>
+            )}
+
+            {/* ── メモ（予定通りのみ）── */}
+            {status === 'work' && (
+              <div>
+                <label className="mb-1 block text-[11px] text-[rgba(247,244,237,0.7)]">メモ（任意）</label>
+                <input
+                  name="memo"
+                  type="text"
+                  defaultValue={existing?.memo && !existing.memo.includes('同伴') ? existing.memo : ''}
+                  placeholder="補足があれば入力してください"
+                  disabled={isLocked}
+                  className={inputClass}
+                />
+              </div>
+            )}
+
+            {/* ── 休み（警告） ── */}
+            {status === 'absent' && !isLocked && (
+              <div className="rounded-[14px] bg-[rgba(224,106,106,0.1)] p-4">
+                <p className="text-[13px] font-bold text-[#e06a6a] leading-relaxed">
+                  当日欠勤は罰金の対象となります。<br />
+                  やむを得ない場合を除き、十分ご注意ください。
+                </p>
+              </div>
+            )}
+
+            {/* ── Submit（単体使用時のみ）── */}
+            {!hideSubmitButton && (
+              <button
+                type="submit"
+                disabled={isSubmitting || isLocked}
+                className="h-[52px] w-full rounded-[14px] bg-[rgba(255,255,255,0.05)] text-[14px] font-bold text-[#a9afbc] transition-all disabled:opacity-50 hover:bg-[rgba(255,255,255,0.08)]"
+              >
+                {isSubmitting ? '送信中...' : submitted ? '提出内容を更新する' : '確認を送信する'}
+              </button>
+            )}
+          </form>
+        </div>
       </div>
     )
-  }
-
-  const statusLabel =
-    approvalStatus === 'pending'
-      ? '店長承認待ち'
-      : approvalStatus === 'rejected'
-        ? '差し戻し'
-        : approvalStatus === 'approved'
-          ? '承認済み'
-          : '未提出'
-
-  // ── Card style helpers ──
-  function cardClass(s: Status): string {
-    const base = 'flex-1 rounded-[14px] px-3 py-4 text-center transition-all duration-200 cursor-pointer outline-none focus:outline-none ring-0 focus:ring-0 appearance-none'
-    if (status !== s) {
-      return `${base} border border-[#2a2d36] bg-[#1a1d24] text-[rgba(247,244,237,0.4)] hover:bg-[#1f222a]`
-    }
-    if (s === 'work') {
-      return `${base} border border-[#c9a76a] bg-[rgba(201,167,106,0.15)] text-[#c9a76a] shadow-[0_0_12px_rgba(201,167,106,0.15)]`
-    }
-    if (s === 'douhan') {
-      return `${base} border border-[#9fbc73] bg-[rgba(159,188,115,0.16)] text-[#c8d99a] shadow-[0_0_14px_rgba(159,188,115,0.16)]`
-    }
-    // absent
-    return `${base} border border-[#d4785a] bg-[rgba(212,120,90,0.14)] text-[#e08a73] shadow-[0_0_12px_rgba(212,120,90,0.14)]`
-  }
-
-  return (
-    <div className="rounded-[18px] card-premium-skin">
-      <div className="card-premium-skin__surface rounded-[18px] overflow-hidden px-[18px] py-[18px]">
-      {/* Header */}
-      <div className="mb-4 flex items-center justify-between gap-3">
-        <p className="text-[10px] font-bold tracking-[1.2px] uppercase text-[#6b7280]">
-          01 — 本日の出勤確認
-        </p>
-        <span
-          className={`rounded-full px-2.5 py-1 text-[10px] font-bold ${
-            approvalStatus === 'approved'
-              ? 'bg-[rgba(51,179,107,0.12)] text-[#33b36b]'
-              : approvalStatus === 'rejected'
-                ? 'bg-[rgba(224,106,106,0.12)] text-[#e06a6a]'
-                : approvalStatus === 'pending'
-                  ? 'bg-[rgba(230,162,60,0.12)] text-[#e6a23c]'
-                  : 'bg-[rgba(255,255,255,0.08)] text-[#6b7280]'
-          }`}
-        >
-          {statusLabel}
-        </span>
-      </div>
-
-      {/* Master override banner */}
-      {isMasterOverride && (
-        <div className="mb-4 flex items-center gap-2 rounded-xl border border-[#dfbd69]/30 bg-[rgba(223,189,105,0.08)] px-3 py-2">
-          <span className="shrink-0 rounded-full bg-[#dfbd69] px-2 py-0.5 text-[9px] font-bold tracking-widest text-[#0b0d12] uppercase">
-            MASTER
-          </span>
-          <p className="text-[11px] font-bold text-[#dfbd69]">
-            管理者オーバーライド中 — テストモード（締切後も編集可）
-          </p>
-        </div>
-      )}
-
-      {/* Status banners */}
-      {isSubmissionClosed ? (
-        <p className="mb-4 rounded-xl border border-red-100 bg-red-50 px-3 py-2 text-xs text-red-600">
-          本日の提出締切 {deadlineLabel} を過ぎたため、現在は編集できません。
-        </p>
-      ) : approvalStatus === 'pending' ? (
-        <p className="mb-4 rounded-xl border border-amber-100 bg-amber-50 px-3 py-2 text-xs text-amber-700">
-          提出済みです。店長の承認後に管理画面へ反映されます。
-        </p>
-      ) : approvalStatus === 'rejected' ? (
-        <p className="mb-4 rounded-xl border border-red-100 bg-red-50 px-3 py-2 text-xs text-red-600">
-          差し戻しされています。内容を見直して再提出してください。
-        </p>
-      ) : null}
-
-      {submitError ? (
-        <p className="mb-4 rounded-xl border border-red-100 bg-red-50 px-3 py-2 text-xs text-red-600">
-          {submitError}
-        </p>
-      ) : null}
-
-      <form onSubmit={handleSubmit} className="space-y-5">
-        {/* ── 3-state selector ── */}
-        <div className="grid grid-cols-3 gap-2">
-          {/* 予定通り */}
-          <button
-            type="button"
-            disabled={isLocked}
-            onClick={() => setStatus('work')}
-            className={cardClass('work')}
-          >
-            <div className="text-[14px] font-bold leading-[21px]">予定通り</div>
-            <div className="mt-1 text-[10px] opacity-70">出勤</div>
-          </button>
-
-          {/* 同伴 */}
-          <button
-            type="button"
-            disabled={isLocked}
-            onClick={() => setStatus('douhan')}
-            className={cardClass('douhan')}
-          >
-            <div className="text-[14px] font-bold leading-[21px]">同伴</div>
-            <div className="mt-1 text-[10px] opacity-70">出勤</div>
-          </button>
-
-          {/* 休み */}
-          <button
-            type="button"
-            disabled={isLocked}
-            onClick={handleAbsentClick}
-            className={cardClass('absent')}
-          >
-            <div className="text-[14px] font-bold leading-[21px]">休み</div>
-            <div className="mt-1 text-[10px] opacity-70">欠勤</div>
-          </button>
-        </div>
-
-        {/* ── 同伴フォーム（必須）── */}
-        {status === 'douhan' && (
-          <div className="rounded-[14px] ring-1 ring-[#9fbc73]/20 bg-[rgba(159,188,115,0.06)] p-4 space-y-4">
-            <p className="text-[10px] font-bold tracking-[1.2px] uppercase text-[#c8d99a]/75 mb-1">
-              同伴情報（必須）
-            </p>
-            <div>
-              <label className="mb-1 block text-[11px] text-[#6b7280]">
-                時間 <span className="text-[#dfbd69]">*</span>
-              </label>
-              <input
-                name="douhan_visit_time"
-                type="time"
-                required={status === 'douhan'}
-                defaultValue={existingDouhan?.visit_time?.slice(0, 5) ?? ''}
-                disabled={isLocked}
-                className={inputClass}
-              />
-            </div>
-            <div>
-              <label className="mb-1 block text-[11px] text-[#6b7280]">
-                お客様名 <span className="text-[#dfbd69]">*</span>
-              </label>
-              <input
-                name="douhan_guest_name"
-                type="text"
-                required={status === 'douhan'}
-                defaultValue={existingDouhan?.guest_name ?? ''}
-                placeholder="山田"
-                disabled={isLocked}
-                className={inputClass}
-              />
-              <p className="mt-1 text-[11px] text-[#6b7280]">「様」はつけずに入力してください</p>
-            </div>
-            <div>
-              <label className="mb-1 block text-[11px] text-[#6b7280]">人数</label>
-              <input
-                name="douhan_guest_count"
-                type="number"
-                min="1"
-                inputMode="numeric"
-                placeholder="2"
-                defaultValue={existingDouhan?.guest_count ?? ''}
-                disabled={isLocked}
-                className={inputClass}
-              />
-            </div>
-            <div className="pt-2 border-t border-[#dfbd69]/10">
-              <label className="mb-1 block text-[11px] text-[rgba(247,244,237,0.7)]">変更内容（任意）</label>
-              <input
-                name="change_note"
-                type="text"
-                placeholder="22:00→23:00"
-                defaultValue={existing?.change_note ?? ''}
-                disabled={isLocked}
-                className={inputClass}
-              />
-            </div>
-            <div>
-              <label className="mb-1 block text-[11px] text-[rgba(247,244,237,0.7)]">メモ（任意）</label>
-              <input
-                name="douhan_note"
-                type="text"
-                placeholder="待ち合わせ場所や補足があれば入力してください"
-                defaultValue={existingDouhan?.note ?? ''}
-                disabled={isLocked}
-                className={inputClass}
-              />
-            </div>
-          </div>
-        )}
-
-        {/* ── メモ（予定通りのみ）── */}
-        {status === 'work' && (
-          <div>
-            <label className="mb-1 block text-[11px] text-[rgba(247,244,237,0.7)]">メモ（任意）</label>
-            <input
-              name="memo"
-              type="text"
-              defaultValue={existing?.memo && !existing.memo.includes('同伴') ? existing.memo : ''}
-              placeholder="補足があれば入力してください"
-              disabled={isLocked}
-              className={inputClass}
-            />
-          </div>
-        )}
-
-        {/* ── 休み（警告） ── */}
-        {status === 'absent' && !isLocked && (
-          <div className="rounded-[14px] bg-[rgba(224,106,106,0.1)] p-4">
-            <p className="text-[13px] font-bold text-[#e06a6a] leading-relaxed">
-              当日欠勤は罰金の対象となります。<br />
-              やむを得ない場合を除き、十分ご注意ください。
-            </p>
-          </div>
-        )}
-
-        {/* ── Submit ── */}
-        <button
-          type="submit"
-          disabled={isSubmitting || isLocked}
-          className="h-[52px] w-full rounded-[14px] bg-[rgba(255,255,255,0.05)] text-[14px] font-bold text-[#a9afbc] transition-all disabled:opacity-50 hover:bg-[rgba(255,255,255,0.08)]"
-        >
-          {isSubmitting
-            ? '送信中...'
-            : submitted
-              ? '提出内容を更新する'
-              : '確認を送信する'}
-        </button>
-      </form>
-      </div>
-    </div>
-  )
-}
+  },
+)

--- a/components/features/today/ReservationForm.tsx
+++ b/components/features/today/ReservationForm.tsx
@@ -1,11 +1,11 @@
 'use client'
 
 import { useEffect, useState, useTransition } from 'react'
-import { addReservation, deleteReservation } from '@/lib/actions/today'
+import { deleteReservation } from '@/lib/actions/today'
 import { toast } from 'sonner'
 import { Plus, Trash2 } from 'lucide-react'
 
-type Reservation = {
+type SavedReservation = {
   id: string
   visit_time: string
   guest_name: string
@@ -14,13 +14,19 @@ type Reservation = {
   note?: string
 }
 
-type CertaintyValue = 'confirmed' | 'maybe' | 'contacting'
-
-function createTempReservationId() {
-  return `temp-reservation-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+export type PendingReservation = {
+  id: string
+  visit_time: string
+  guest_name: string
+  guest_count?: number | null
+  note?: string
 }
 
-function sortReservations(items: Reservation[]) {
+function createTempId() {
+  return `pending-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+}
+
+function sortByTime<T extends { visit_time: string }>(items: T[]): T[] {
   return [...items].sort((a, b) => a.visit_time.localeCompare(b.visit_time))
 }
 
@@ -28,192 +34,228 @@ export function ReservationForm({
   reservations,
   isSubmissionClosed,
   deadlineLabel,
+  pendingReservations = [],
+  onAddPending,
+  onRemovePending,
 }: {
-  reservations: Reservation[]
+  reservations: SavedReservation[]
   isSubmissionClosed: boolean
   deadlineLabel: string
+  pendingReservations?: PendingReservation[]
+  onAddPending?: (r: PendingReservation) => void
+  onRemovePending?: (id: string) => void
 }) {
   const [isPending, startTransition] = useTransition()
   const [localReservations, setLocalReservations] = useState(reservations)
   const [showForm, setShowForm] = useState(false)
-  const [selectedCertainty, setSelectedCertainty] = useState<CertaintyValue>('maybe')
-  const [pendingIds, setPendingIds] = useState<string[]>([])
+  const [pendingDeleteIds, setPendingDeleteIds] = useState<string[]>([])
 
   useEffect(() => {
     setLocalReservations(reservations)
   }, [reservations])
 
-  const inputClass = 'h-[48px] w-full rounded-[12px] bg-black/40 border-none px-3 text-[13px] text-[#f7f4ed] placeholder:text-[rgba(247,244,237,0.4)] focus:outline-hidden focus:ring-1 focus:ring-[#c9a76a] transition-all'
+  const inputClass =
+    'h-[48px] w-full rounded-[12px] bg-black/40 border-none px-3 text-[13px] text-[#f7f4ed] placeholder:text-[rgba(247,244,237,0.4)] focus:outline-hidden focus:ring-1 focus:ring-[#c9a76a] transition-all'
 
-  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+  function handleAddSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault()
     const fd = new FormData(e.currentTarget)
-    fd.set('visit_certainty', selectedCertainty)
-    const previousReservations = localReservations
-    const tempId = createTempReservationId()
     const guestCountValue = String(fd.get('guest_count') ?? '').trim()
-    const tempReservation: Reservation = {
-      id: tempId,
-      visit_time: String(fd.get('visit_time') ?? ''),
-      guest_name: String(fd.get('guest_name') ?? '').trim(),
-      guest_count: guestCountValue ? Number.parseInt(guestCountValue, 10) : null,
-      reservation_type: String(fd.get('reservation_type') ?? 'reservation'),
-      note: String(fd.get('note') ?? '').trim() || undefined,
+
+    if (onAddPending) {
+      // pending mode: just add to local list, no server call
+      onAddPending({
+        id: createTempId(),
+        visit_time: String(fd.get('visit_time') ?? ''),
+        guest_name: String(fd.get('guest_name') ?? '').trim(),
+        guest_count: guestCountValue ? Number.parseInt(guestCountValue, 10) : null,
+        note: String(fd.get('note') ?? '').trim() || undefined,
+      })
+      e.currentTarget.reset()
+      setShowForm(false)
+      return
     }
 
-    setLocalReservations((current) => sortReservations([...current, tempReservation]))
-    setPendingIds((current) => [...current, tempId])
-    setShowForm(false)
-    setSelectedCertainty('maybe')
-
-    startTransition(async () => {
-      const result = await addReservation(fd)
-      if (result.error) {
-        setLocalReservations(previousReservations)
-        setPendingIds((current) => current.filter((id) => id !== tempId))
-        setShowForm(true)
-        toast.error(result.error)
-      } else {
-        toast.success(result.message || '来店予定を追加しました')
-        if ('warning' in result && result.warning) {
-          toast.error(result.warning)
-        }
-        setPendingIds((current) => current.filter((id) => id !== tempId))
-        if ('data' in result && result.data) {
-          const savedReservation = result.data
-          setLocalReservations((current) =>
-            sortReservations(current.map((reservation) =>
-              reservation.id === tempId
-                ? {
-                    id: savedReservation.id,
-                    visit_time: savedReservation.visit_time,
-                    guest_name: savedReservation.guest_name,
-                    guest_count: savedReservation.guest_count ?? null,
-                    reservation_type: savedReservation.reservation_type,
-                    note: savedReservation.note ?? undefined,
-                  }
-                : reservation
-            ))
-          )
-        }
-      }
-    })
+    // standalone mode (no parent shell): kept for backward compatibility
+    toast.error('送信ハンドラが接続されていません')
   }
 
-  async function handleDelete(id: string) {
+  function handleDeleteSaved(id: string) {
     const previousReservations = localReservations
-    setLocalReservations((current) => current.filter((reservation) => reservation.id !== id))
-    setPendingIds((current) => [...current, id])
+    setLocalReservations(current => current.filter(r => r.id !== id))
+    setPendingDeleteIds(current => [...current, id])
 
     startTransition(async () => {
       const result = await deleteReservation(id)
-      setPendingIds((current) => current.filter((pendingId) => pendingId !== id))
+      setPendingDeleteIds(current => current.filter(pid => pid !== id))
       if (result.error) {
         setLocalReservations(previousReservations)
         toast.error(result.error)
-        return
       }
     })
   }
+
+  const sortedSaved = sortByTime(localReservations)
+  const sortedPending = sortByTime(pendingReservations)
+  const totalCount = sortedSaved.length + sortedPending.length
 
   return (
     <div className="rounded-[18px] card-premium-skin">
       <div className="card-premium-skin__surface rounded-[18px] overflow-hidden p-4">
-      <p className="mb-4 text-[10px] font-bold tracking-[1.2px] uppercase text-[#6b7280]">02 — 通常来店予定</p>
-
-      {isSubmissionClosed ? (
-        <p className="mb-4 rounded-xl border border-red-100 bg-red-50 px-3 py-2 text-xs text-red-600">
-          本日の提出締切 {deadlineLabel} を過ぎたため、現在は編集できません。
+        <p className="mb-2 text-[10px] font-bold tracking-[1.2px] uppercase text-[#6b7280]">
+          02 — 通常来店予定
         </p>
-      ) : null}
 
-      {localReservations.length > 0 ? (
-        <div className="mb-4 space-y-3">
-          {localReservations.map(r => (
-            <div key={r.id} className="rounded-[16px] bg-[#131720] p-4">
-              <div className="mb-3 flex items-center justify-between">
-                <div className="flex items-center gap-2 text-[13px] text-[#6b7280]">
-                  <span className="flex h-[22px] w-[22px] items-center justify-center rounded-full bg-[rgba(255,255,255,0.08)] text-[11px] font-bold">{localReservations.findIndex((item) => item.id === r.id) + 1}</span>
-                  {localReservations.findIndex((item) => item.id === r.id) + 1}組目
+        {/* ② 説明文 */}
+        <p className="mb-4 text-[11px] leading-relaxed text-[#8f96a3]">
+          同伴以外の通常来店予定を入力してください
+        </p>
+
+        {isSubmissionClosed ? (
+          <p className="mb-4 rounded-xl border border-red-100 bg-red-50 px-3 py-2 text-xs text-red-600">
+            本日の提出締切 {deadlineLabel} を過ぎたため、現在は編集できません。
+          </p>
+        ) : null}
+
+        {/* Saved reservations */}
+        {totalCount > 0 ? (
+          <div className="mb-4 space-y-3">
+            {sortedSaved.map((r, i) => (
+              <div key={r.id} className="rounded-[16px] bg-[#131720] p-4">
+                <div className="mb-3 flex items-center justify-between">
+                  <div className="flex items-center gap-2 text-[13px] text-[#6b7280]">
+                    <span className="flex h-[22px] w-[22px] items-center justify-center rounded-full bg-[rgba(255,255,255,0.08)] text-[11px] font-bold">
+                      {i + 1}
+                    </span>
+                    {i + 1}組目
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() => handleDeleteSaved(r.id)}
+                    disabled={pendingDeleteIds.includes(r.id) || isPending}
+                    className="text-[#6b7280] disabled:opacity-40"
+                  >
+                    <Trash2 size={14} />
+                  </button>
                 </div>
-                <button
-                  onClick={() => handleDelete(r.id)}
-                  disabled={pendingIds.includes(r.id)}
-                  className="text-[#6b7280] disabled:opacity-40"
-                >
-                  <Trash2 size={14} />
-                </button>
+                <div className="grid gap-3">
+                  <div className="grid grid-cols-[1fr_auto] items-center gap-3">
+                    <div className="text-[13px] text-[#f7f4ed]">{r.guest_name}様</div>
+                    <div className="text-[13px] font-medium text-[#f7f4ed]">
+                      {r.visit_time.substring(0, 5)}
+                    </div>
+                  </div>
+                  <div className="text-[12px] text-[#6b7280]">{r.guest_count ?? 1}名</div>
+                </div>
               </div>
-              <div className="grid gap-3">
-                <div className="grid grid-cols-[1fr_auto] items-center gap-3">
-                  <div className="text-[13px] text-[#f7f4ed]">{r.guest_name}様</div>
-                  <div className="text-[13px] font-medium text-[#f7f4ed]">{r.visit_time.substring(0, 5)}</div>
+            ))}
+
+            {/* Pending (not yet submitted) reservations */}
+            {sortedPending.map((r, i) => (
+              <div key={r.id} className="rounded-[16px] bg-[#131720] p-4 ring-1 ring-[#c9a76a]/20">
+                <div className="mb-3 flex items-center justify-between">
+                  <div className="flex items-center gap-2 text-[13px] text-[#6b7280]">
+                    <span className="flex h-[22px] w-[22px] items-center justify-center rounded-full bg-[rgba(255,255,255,0.08)] text-[11px] font-bold">
+                      {sortedSaved.length + i + 1}
+                    </span>
+                    {sortedSaved.length + i + 1}組目
+                    <span className="rounded-full bg-[rgba(201,167,106,0.15)] px-2 py-0.5 text-[9px] font-bold text-[#c9a76a]">
+                      未送信
+                    </span>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() => onRemovePending?.(r.id)}
+                    className="text-[#6b7280]"
+                  >
+                    <Trash2 size={14} />
+                  </button>
                 </div>
-                <div className="grid grid-cols-[80px_1fr] gap-3">
-                  <div className="rounded-[10px] bg-[#131720] px-3 py-2 text-[13px] text-[#f7f4ed]">{r.guest_count ?? 1}名</div>
+                <div className="grid gap-3">
+                  <div className="grid grid-cols-[1fr_auto] items-center gap-3">
+                    <div className="text-[13px] text-[#f7f4ed]">{r.guest_name}様</div>
+                    <div className="text-[13px] font-medium text-[#f7f4ed]">
+                      {r.visit_time.substring(0, 5)}
+                    </div>
+                  </div>
+                  <div className="text-[12px] text-[#6b7280]">{r.guest_count ?? 1}名</div>
                 </div>
               </div>
+            ))}
+          </div>
+        ) : (
+          <p className="mb-4 text-[13px] text-[#a9afbc]">来店予定がある方は入力してください</p>
+        )}
+
+        {/* Add form */}
+        {showForm && !isSubmissionClosed ? (
+          <form onSubmit={handleAddSubmit} className="space-y-4 rounded-[16px] bg-[#131720] p-4">
+            <div>
+              <label className="mb-1 block text-[11px] text-[rgba(247,244,237,0.7)]">時間 *</label>
+              <input name="visit_time" type="time" required className={inputClass} />
             </div>
-          ))}
-        </div>
-      ) : (
-        <p className="mb-4 text-[13px] text-[#a9afbc]">来店予定がある方は入力してください</p>
-      )}
-
-      {showForm && !isSubmissionClosed ? (
-        <form onSubmit={handleSubmit} className="space-y-4 rounded-[16px] bg-[#131720] p-4">
-          <div>
-            <label className="mb-1 block text-[11px] text-[rgba(247,244,237,0.7)]">時間 *</label>
-            <input name="visit_time" type="time" required className={inputClass} />
-          </div>
-          <div>
-            <label className="mb-1 block text-[11px] text-[#6b7280]">お客様名 *</label>
-            <input name="guest_name" type="text" required placeholder="山田" className={inputClass} />
-            <p className="mt-1 text-[11px] text-[#6b7280]">「様」はつけずに入力してください</p>
-          </div>
-          <div>
-            <label className="mb-1 block text-[11px] text-[#6b7280]">人数</label>
-            <input
-              name="guest_count"
-              type="number"
-              min="1"
-              inputMode="numeric"
-              placeholder="2"
-              className={inputClass}
-            />
-          </div>
-          <input type="hidden" name="reservation_type" value="reservation" />
-          <div>
-            <label className="mb-1 block text-[11px] text-[rgba(247,244,237,0.7)]">メモ（任意）</label>
-            <input name="note" type="text" placeholder="テーブル、備考など" className={inputClass} />
-          </div>
-          <div className="flex gap-2 pt-1">
-            <button
-              type="submit"
-              disabled={isPending}
-              className="flex-1 rounded-[12px] bg-[#c9a76a] py-3 text-[13px] font-bold text-[#0b0d12] disabled:opacity-50"
-            >
-              {isPending ? '追加中...' : '追加する'}
-            </button>
-            <button
-              type="button"
-              onClick={() => setShowForm(false)}
-              className="rounded-[12px] bg-white/5 hover:bg-white/10 px-4 py-3 text-[13px] text-[#f7f4ed] transition-colors"
-            >
-              キャンセル
-            </button>
-          </div>
-        </form>
-      ) : (
-        <button
-          disabled={isSubmissionClosed}
-          onClick={() => setShowForm(true)}
-          className="flex h-[50px] w-full items-center justify-center gap-2 rounded-[14px] bg-[rgba(255,255,255,0.03)] text-[13px] text-[#f7f4ed]/70 hover:bg-[rgba(255,255,255,0.06)] transition-colors disabled:cursor-not-allowed disabled:opacity-50"
-        >
-          <Plus size={14} />
-          来店予定を追加
-        </button>
-      )}
+            <div>
+              <label className="mb-1 block text-[11px] text-[#6b7280]">お客様名 *</label>
+              <input
+                name="guest_name"
+                type="text"
+                required
+                placeholder="山田"
+                className={inputClass}
+              />
+              <p className="mt-1 text-[11px] text-[#6b7280]">「様」はつけずに入力してください</p>
+            </div>
+            <div>
+              <label className="mb-1 block text-[11px] text-[#6b7280]">人数</label>
+              <input
+                name="guest_count"
+                type="number"
+                min="1"
+                inputMode="numeric"
+                placeholder="2"
+                className={inputClass}
+              />
+            </div>
+            <input type="hidden" name="reservation_type" value="reservation" />
+            <div>
+              <label className="mb-1 block text-[11px] text-[rgba(247,244,237,0.7)]">
+                メモ（任意）
+              </label>
+              <input
+                name="note"
+                type="text"
+                placeholder="テーブル、備考など"
+                className={inputClass}
+              />
+            </div>
+            <div className="flex gap-2 pt-1">
+              <button
+                type="submit"
+                disabled={isPending}
+                className="flex-1 rounded-[12px] bg-[#c9a76a] py-3 text-[13px] font-bold text-[#0b0d12] disabled:opacity-50"
+              >
+                リストに追加
+              </button>
+              <button
+                type="button"
+                onClick={() => setShowForm(false)}
+                className="rounded-[12px] bg-white/5 hover:bg-white/10 px-4 py-3 text-[13px] text-[#f7f4ed] transition-colors"
+              >
+                キャンセル
+              </button>
+            </div>
+          </form>
+        ) : (
+          <button
+            type="button"
+            disabled={isSubmissionClosed}
+            onClick={() => setShowForm(true)}
+            className="flex h-[50px] w-full items-center justify-center gap-2 rounded-[14px] bg-[rgba(255,255,255,0.03)] text-[13px] text-[#f7f4ed]/70 hover:bg-[rgba(255,255,255,0.06)] transition-colors disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            <Plus size={14} />
+            来店予定を追加
+          </button>
+        )}
       </div>
     </div>
   )


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **①** `CheckinForm` の単独送信ボタンを `hideSubmitButton` prop で非表示化。`forwardRef` + `useImperativeHandle` で `submit()` ハンドルを公開し、親シェルから呼び出し可能に。
- **②** `ReservationForm` のヘッダ直下に「同伴以外の通常来店予定を入力してください」説明文を追加。
- **③** 「追加する」ボタンをサーバ非送信に変更。`onAddPending` コールバックでローカル state にのみ追加。未送信アイテムは gold の「未送信」バッジ付きでリスト表示・削除可能。
- **④** 変更内容フィールドのラベル横に「例：来店時間の変更など」ヒントを追加、placeholder を `例：22:00→23:00` に更新。
- **⑤** TODAY'S SCHEDULE ラベルのクリッピング修正: `CastMobileCard` 外側 div の `px-5 py-4` を内側コンテンツ div に移動し、`card-premium-skin` の 1px ゴールドベゼルが正しく表示されるよう修正。
- 新規 `CastTodayClientShell.tsx`: 01 + 02 を束ね、ページ末尾に「本日の情報を送信する」ボタン 1 つを配置。送信時は `submitCheckin` → 各 pending reservation の `addReservation` を順次実行。

## Test plan

- [ ] 01「同伴」選択 → フォーム展開 → **単独送信ボタンが表示されないこと**
- [ ] 02「来店予定を追加」→「リストに追加」押下 → **DB に即送信されないこと**（未送信バッジ表示）
- [ ] 複数組追加 → 削除ボタンで未送信リストから削除
- [ ] ページ末尾「本日の情報を送信する」1 回押下で 01 + 02 両方が正常送信
- [ ] 送信済み予約は削除ボタン押下でサーバから即時削除
- [ ] TODAY'S SCHEDULE ラベルが枠に被らず正しく表示されること（モバイル 375px 幅実機確認）
- [ ] 締切後 / 承認済み状態で送信ボタンが非表示になること

https://claude.ai/code/session_01Rpbzb3ay87L43coMsJuZRo
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rpbzb3ay87L43coMsJuZRo)_