### PR TITLE
fix(today): キャスト出勤トグルがリフレッシュで消える問題を修正

### DIFF
--- a/lib/actions/today.ts
+++ b/lib/actions/today.ts
@@ -313,6 +313,27 @@ export async function getTodayDashboard(dateStr?: string): Promise<TodayDashboar
     (manualAttendanceRaw || []).map((row) => [row.cast_id, row.status as DailyCastAttendanceStatus])
   )
 
+  // シフト未提出で「出勤」に手動オーバーライドされたキャストを todayShifts に合流
+  // （TodayDesktopView / generateLineText が data.shifts を起点にするため、ここで補完）
+  const existingShiftCastIds = new Set(todayShifts.map((s) => s.cast_id))
+  const manualWorkingOnlyIds = (manualAttendanceRaw || [])
+    .filter((row) => row.status === 'working' && !existingShiftCastIds.has(row.cast_id))
+    .map((row) => row.cast_id)
+  if (manualWorkingOnlyIds.length > 0) {
+    const { data: extraCasts } = await supabase
+      .from('casts')
+      .select('id, stage_name')
+      .in('id', manualWorkingOnlyIds)
+    for (const cast of extraCasts ?? []) {
+      todayShifts.push({
+        cast_id: cast.id,
+        stage_name: (cast.stage_name as string) || '不明',
+        start_time: '20:00',
+      })
+    }
+    todayShifts.sort((a, b) => a.start_time.localeCompare(b.start_time))
+  }
+
   // 当日変更
   const { data: changesRaw } = await supabase
     .from('shift_changes')
@@ -1081,7 +1102,12 @@ export async function getTodayCastAttendanceStatuses(): Promise<Record<string, D
 
   const today = getJstDateString()
 
-  const { data, error } = await supabase
+  // Read via service role: RLS on daily_cast_attendance references public.user_roles
+  // which is not provisioned via migrations in this repo (admin role lives in `profiles`).
+  // Auth + role gate already enforced above; using service client keeps read consistent
+  // with `updateDailyCastAttendance` writes.
+  const serviceSupabase = createServiceClient()
+  const { data, error } = await serviceSupabase
     .from('daily_cast_attendance')
     .select('cast_id, status')
     .eq('business_date', today)


### PR DESCRIPTION
## Summary

PR #56 で merge された修正は **dashboard 側の集計のみ** で、キャスト管理ページの「出勤/休み」トグルが**リフレッシュ後に消える**問題と、`/admin/today`（本日の営業状況）に手動出勤が反映されない問題は未解決のままだったので、本 PR で追補する。

## 直す症状

- ✗ キャスト管理で「出勤」を押す → トースト出る → DB に書き込まれる → **画面リロードでトグルが「未設定」に戻る**
- ✗ シフト未提出のキャストを「出勤」にしても `/admin/today` ページの本日の営業状況キャストリスト・LINE Distribution Text に出てこない

## 原因

1. `getTodayCastAttendanceStatuses` (`lib/actions/today.ts`) が通常 SSR クライアントで `daily_cast_attendance` を SELECT。同テーブルの RLS は `public.user_roles` テーブル（このリポジトリのマイグレーションには存在せず、admin role は `profiles` 側）を参照するため authenticated でも常に空配列が返る。書き込み (`updateDailyCastAttendance`) は `serviceSupabase` でバイパスしていたため成功 → DB には行が入るが、再描画時の読み取りで取れず「未設定」表示に戻っていた。

2. `getTodayDashboard.todayShifts` は承認済 `shift_submissions` のみから構築されるため、シフト未提出キャストを手動「出勤」にしても TodayDesktopView/LINE文章の active casts 経路に乗らなかった。

## 修正内容

`lib/actions/today.ts` のみ（+27/-1）

1. `getTodayCastAttendanceStatuses`: 認証/admin role チェック後の SELECT を `serviceSupabase` に切替（`updateDailyCastAttendance` の書き込みと一貫）
2. `getTodayDashboard`: `manualAttendanceMap` 構築直後に manual='working' でシフト未提出のキャストを `casts` テーブルから `stage_name` 解決して `todayShifts` に合流（既定 `start_time='20:00'`）
   - `absentCastIds` 判定: 合流エントリは status='working' のため絶対 absent にならない
   - `unconfirmedCasts` 判定: `manualAttendanceMap.has=true` なので未確認には入らない

## スコープ外（無変更）

- 承認ハブ UI（既に `ApprovalActionPair` で別実装済を尊重）
- スタッフ管理 UI
- LINE 文章フォーマット
- RLS マイグレーション

## Verification

```
pnpm lint   # 0 errors
npx tsc --noEmit   # exit 0
```

実機検証手順（Vercel preview もしくはマージ後の本番）:
1. キャスト管理ページで誰かを「出勤」に切り替える
2. **F5 で同ページをリロード** → 緑表示が**保持される**
3. `/admin/dashboard` をリロード → 出勤人数 KPI と本日の出勤キャスト一覧に反映
4. `/admin/today` をリロード → 本日の営業状況のキャスト一覧と下部 LINE Distribution Text に反映


---
_Generated by [Claude Code](https://claude.ai/code/session_01Wwr1srVj1p5EMEkZd2DaV8)_