### PR TITLE
docs(plan): Add admin/cast v2 parallel rebuild planning

### DIFF
--- a/PLANS.md
+++ b/PLANS.md
@@ -408,3 +408,10 @@ validation:
 
 next step:
 - ...
+
+### Admin/Cast v2 parallel rebuild planning (2026-05-15)
+
+- **Approval:** [?] Needs decision (master)
+- **Status:** [~] In progress (planning only)
+- **Plan doc:** `docs/plans/2026-05-15-admin-cast-v2-rebuild-plan.md`
+- **Guardrails:** Keep existing `app/admin` and `app/(cast)/cast` unchanged; build in `app/admin-v2` and `app/cast-v2`.

--- a/daily_log.md
+++ b/daily_log.md
@@ -243,3 +243,10 @@ Context rule: before starting work, read `CURRENT_STATE.md` plus only the latest
 - files changed: `lib/actions/cast-auth.ts`, `app/(cast)/cast/profile/page.tsx`, `daily_log.md`.
 - validation: Targeted eslint passed for `lib/actions/cast-auth.ts` and `app/(cast)/cast/profile/page.tsx`; `git diff --check` passed; `pnpm lint` passed with existing warnings only; `pnpm build` passed.
 - remaining risks: Live browser verification is needed to confirm the next `/cast/login` visit redirects without SMS after using `アプリを終了`.
+
+### 2026-05-15 (admin/cast v2 planning inventory)
+
+- scope: Read-only investigation and implementation planning for parallel `admin-v2` / `cast-v2` rebuild, with no code-path or DB changes.
+- files changed: `docs/plans/2026-05-15-admin-cast-v2-rebuild-plan.md`, `PLANS.md`, `daily_log.md`.
+- validation: File-based inventory via `rg --files` and dependency mapping via `rg -n` completed; no runtime/build command executed because this turn is docs/planning only.
+- remaining risks: Requested investigation target `prisma/schema.prisma` is not present in current repository; DB shape must be inferred from Supabase migrations/actions until owner clarifies canonical schema source.

--- a/docs/plans/2026-05-15-admin-cast-v2-rebuild-plan.md
+++ b/docs/plans/2026-05-15-admin-cast-v2-rebuild-plan.md
@@ -1,0 +1,67 @@
+# Club Animo Admin/Cast v2 Rebuild Plan (Read-only investigation)
+
+## 0) Scope and hard constraints
+- Keep existing `app/admin` and `app/(cast)/cast` untouched.
+- Build parallel v2 routes: `app/admin-v2` and `app/cast-v2`.
+- Reuse Supabase DB/Auth/env/Vercel.
+- No public site changes.
+- No data deletion.
+- No route replacement until v2 completion review.
+
+## 1) 現行機能棚卸し（実ファイルベース）
+- Admin: dashboard/today/approvals/shift/customers/casts/staff/posts/settings/analytics/internal-notices.
+- Cast: login/register/otp/dashboard/today/shift/monthly-shift/posts/notices/profile.
+- Shared: `components/features/admin/**`, `components/features/cast/**`, `lib/actions/**`, `app/api/**`.
+
+## 2) v2で残す機能
+- Auth and role gates.
+- Today operation + approvals + shift lifecycle.
+- Profile change request workflow.
+- Posts submit/moderation/publish flow.
+- Notices and notification systems.
+- Core cast/customer/staff operations.
+
+## 3) v2で捨てる機能
+- Duplicate UX paths with same business result.
+- Non-operational/debug exposure in normal UI.
+- UI-only placeholders and disconnected actions.
+
+## 4) v2で新規作成する機能
+- Isolated route shells for `admin-v2` / `cast-v2`.
+- `lib/actions-v2/*` facade layer for v2-specific action ownership.
+- Mandatory mutation audit log wrapper for DB updates.
+- Button contract registry (1 button = 1 purpose = 1 endpoint).
+
+## 5) DB接続マップ
+- Session client: `lib/supabase/client.ts`, `lib/supabase/server.ts`, `lib/supabase/middleware.ts`.
+- Privileged/system: `lib/supabase/service.ts` + cron/webhook/api routes.
+- LINE integration: `lib/line.ts`, `app/api/line/webhook/route.ts`, `app/api/line/route.ts`, `app/api/cron/line-notifications/route.ts`.
+
+## 6) 画面遷移マップ
+- Admin v2: login -> dashboard -> today/approvals/shift-requests/human-resources/customers/posts/settings/analytics.
+- Cast v2: login -> dashboard -> today/shift/monthly-shift/posts/notices/profile.
+
+## 7) ボタン接続マップ
+- Every button must have: purpose ID, exactly one action/API target, success/fail feedback, and mutation log on write.
+- No decorative action buttons.
+
+## 8) 推奨ディレクトリ構成
+- `app/admin-v2/(auth)/*`, `app/admin-v2/(protected)/*`
+- `app/cast-v2/(auth)/*`, `app/cast-v2/(protected)/*`
+- `components/features/admin-v2/*`, `components/features/cast-v2/*`
+- `lib/actions-v2/admin/*`, `lib/actions-v2/cast/*`, `lib/actions-v2/shared/*`
+
+## 9) 実装フェーズ分け
+1. Read-only inventory finalize.
+2. Keep/drop/new decision + button contracts.
+3. v2 route/auth/layout scaffolding.
+4. Admin domain migration.
+5. Cast domain migration.
+6. Integration and side-effect verification.
+7. Parallel-run QA.
+8. Cutover decision (no replacement yet).
+
+## 10) リスクと検証項目
+- Risks: hidden coupling, RLS-sensitive writes, notification side effects, route confusion during parallel run.
+- Verification: per-route role checks, per-button connection checks, per-mutation audit log checks, `pnpm lint`/`pnpm build` per milestone.
+- Note: `prisma/schema.prisma` is not present in this repository; DB reference is Supabase migrations + existing actions.


### PR DESCRIPTION
### Motivation
- 既存の `app/admin` と `app/(cast)/cast` を触らずに並行して `admin-v2` / `cast-v2` を作るための、安全な実装計画をファイルベースの調査に基づいて用意する必要があった。 
- 現行コードベースの実ファイルから残す/捨てる/新規領域を明確にし、ボタン→サーバーアクション接続ルールや監査ログ要件を決める必要があった。 
- 調査中に `prisma/schema.prisma` がリポジトリに存在しないことが判明したため、Supabase マイグレーションを参照する運用上の注意を残す必要があった。 

### Description
- 新規に `docs/plans/2026-05-15-admin-cast-v2-rebuild-plan.md` を追加し、現行機能の棚卸し・v2で残す/捨てる/新規の方針・DB接続マップ・画面遷移やボタン接続ルール・推奨ディレクトリ構成・実装フェーズ・リスク/検証項目を記載した。 
- `PLANS.md` に今回の計画エントリを追加して進行管理エントリを登録した（承認待ちステータスの記載を含む）。 
- `daily_log.md` に今回の調査実行ログを追記して「調査のみ・非破壊・DB変更なし」であることと残存リスク（`prisma/schema.prisma` 不在）を記録した。 
- これらはドキュメントのみの変更であり、アプリルート/DB/認証/既存UI実装には一切手を入れていない。 

### Testing
- ファイルベースのインベントリを確認するために `rg --files` を実行して対象ファイル群を列挙し、依存関係のスコープ確認に `rg -n "createClient|supabase|line|LINE|notify|notification|send"` を用いて関連箇所を抽出し内容を検査した。 
- 追加した計画ドキュメントの内容はリポジトリ内参照と照合して行番号表示（`nl` 相当の確認）で目視確認を行った。 
- 変更はドキュメントのみのため `pnpm lint` / `pnpm build` の実行は必須ではなく実行していないが、各フェーズでのマージ前には `pnpm lint` と `pnpm build` を実行する旨を計画に明記している。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a073e579a0883218485c8f5f811e76e)