### PR TITLE
fix(cast-posts): キャストのブログ投稿エラーを修正（RLS INSERT ポリシー不足）

### DIFF
--- a/lib/actions/cast-posts.ts
+++ b/lib/actions/cast-posts.ts
@@ -84,9 +84,10 @@ export async function createCastPost(formData: FormData) {
       .getPublicUrl(uploadData.path);
 
     // データベース (cast_posts) へ保存
-    // cast_insert_own_posts RLS ポリシーが「auth_user_id = auth.uid() のキャスト」への
-    // INSERT を許可するため、所有者検証済みの SSR クライアントで保存する。
-    const { error: dbError } = await supabase
+    // cast_posts の INSERT RLS ポリシーはキャスト向けに未定義のため、
+    // 所有権検証済みの後はサービスクライアントで INSERT する。
+    const serviceClient = createServiceClient();
+    const { error: dbError } = await serviceClient
       .from('cast_posts')
       .insert({
         cast_id: castId,


### PR DESCRIPTION
## 概要

キャストがブログを投稿するとエラーになる問題を修正しました。

## 根本原因

`cast_posts` テーブルに **キャスト会員向けの INSERT RLS ポリシーが存在しない**ことが原因です。

マイグレーション `20260315000000_add_cast_posts.sql` に定義されている RLS ポリシー：
- `admin_all_cast_posts` — 管理者（owner/manager）の全操作を許可
- `cast_own_posts_select` — キャスト会員の **SELECT のみ**許可 ← INSERT は許可されていない
- `public_read_published_cast_posts` — 公開済み投稿の閲覧許可

`createCastPost` server action（`lib/actions/cast-posts.ts:89`）では認証クライアント（`supabase`）で `cast_posts` に INSERT していたため、RLS により毎回拒否されていました。

## 修正内容

所有権検証済みの後、`createServiceClient()`（RLS バイパス）で INSERT するように変更。

**フロー（変更後）**:
1. `createClient()` で認証確認 ✅
2. `casts` テーブルで `auth_user_id = user.id` による所有権検証 ✅
3. Storage へ画像アップロード（認証クライアント）✅
4. `createServiceClient()` で `cast_posts` に INSERT ✅ ← ここを修正

## 変更ファイル

- `lib/actions/cast-posts.ts` — `supabase.from('cast_posts').insert(...)` を `serviceClient.from('cast_posts').insert(...)` に変更（3行）

## テスト項目

- [ ] キャストがブログを投稿できる
- [ ] 投稿後に「管理者の確認後に公開されます」トーストが表示される
- [ ] 管理画面 `/admin/posts` に承認待ちで表示される

## スコープ適合確認

- 変更は最小差分（`createCastPost` 関数の INSERT クライアントのみ）
- 所有権検証は変更前と同じ（バイパスは INSERT のみ、所有権確認後）
- 関係ないファイルは無変更

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ps5LRwUT1adRy9vFwXrwYu)_